### PR TITLE
Keya CAN motor support (build-flag selectable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,34 @@ src/
 
 ## Configuration
 
-Settings can be configured through the web interface (connect to device's IP) or by modifying defaults in the code. 
+Settings can be configured through the web interface (connect to device's IP) or by modifying defaults in the code.
+
+## Build environments
+
+The same source tree builds several variants. Pick one with `pio run -e <name>`:
+
+| env | Motor backend | GPS layout | Upload | Notes |
+|---|---|---|---|---|
+| `esp32-s3` | PWM (Cytron/Danfoss) | single-GPS PCB | esp-builtin JTAG | default |
+| `esp32-s3_dual_gps` | PWM | dual-antenna heading | esp-builtin JTAG | for PCBs with the second u-blox |
+| `esp32-s3_keya` | Keya CAN bus | single-GPS PCB | esp-builtin JTAG | requires CAN transceiver populated |
+| `esp32-s3_keya_noack` | Keya CAN, NO_ACK | single-GPS PCB | esp-builtin JTAG | bench/sniffer only - won't engage |
+| `esp32-s3_serial` | (inherits) | (inherits) | esptool / download mode | fallback when JTAG endpoint is unavailable |
+| `esp32-s3_ota` | (inherits) | (inherits) | espota over LAN | requires device already running an OTA-capable firmware |
+| `native` | n/a | n/a | n/a | Unity unit tests |
+
+Build flags driving the matrix:
+- `KEYA_MOTOR=0|1` — selects PWM vs Keya CAN motor backend.
+- `GPS_HEADING=0|1` — enables the dual-antenna heading GPS path.
+- `KEYA_NO_ACK=0|1` — runs the TWAI driver in NO_ACK mode so a solo board can transmit without another CAN node ACKing. Off in production.
+
+## Bench-testing the Keya backend
+
+`esp32-s3_keya_noack` lets you verify the CAN frame layout without a real Keya motor on the bus:
+
+1. Flash the env. The boot log should show `CAN: NO_ACK mode (bench/sniffer build)` and `CAN: started at 250kbps (TX=21 RX=47)`.
+2. Connect a CAN sniffer (USB-to-CAN, Saleae with the CAN protocol decoder, etc.) to the same bus.
+3. Press the steer button or send a guidance packet from AgOpenGPS so `steerEnable` goes true. With no heartbeat from a real motor, `KeyaMotor::isHealthy()` is false so the engage gate refuses to drive (and logs `Keya motor unhealthy ... refusing engage` over UDP). To still see speed frames on the bus you can temporarily comment out the `if (!isHealthy())` check in `keya_motor.cpp::drive()` — re-enable before going to the field.
+4. Without that override you will see `disable` frames (`23 0C 20 01 ...`) on every cycle when not engaged, which is enough to confirm bus + framing.
+
+When a real Keya motor (or another node emitting `0x07000001` heartbeat frames at ~50 Hz) is on the bus, switch back to `esp32-s3_keya` (ACK on) and engagement will proceed normally.

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,39 @@ build_flags =
 	-DKEYA_WAS=1
 	-DKEYA_SNIFFER=1
 
+; Hardware-validation build. TEST_MODE makes hw::init() failures non-fatal
+; so the firmware boots with whatever subset of peripherals is plugged in.
+; A test task logs the live state of every subsystem at 1 Hz on the UDP
+; debug stream (port 7777) so you can see at a glance which one responds.
+;
+; Use cases:
+;   * GPS-only test : plug GPS, leave IMU/WAS/motor unplugged.
+;                     Watch "TEST GPS: init OK" + live NMEA broadcast on
+;                     UDP port 9999.
+;   * IMU-only test : plug IMU, leave GPS/WAS/motor unplugged.
+;                     Watch "TEST IMU: heading=N.N deg, roll=N.N deg" tick.
+;   * Both          : plug both, see both subsystems update independently.
+;
+; Default motor backend is PWM (no CAN required). For a Keya bench, use
+; esp32-s3_test_keya which adds KEYA_MOTOR=1.
+[env:esp32-s3_test]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DTEST_MODE=1
+
+; TEST_MODE + KEYA_MOTOR for benches that have a Keya motor wired and want
+; to validate it alongside the IMU/GPS without needing AOG to drive the
+; full autosteer loop.
+[env:esp32-s3_test_keya]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DTEST_MODE=1
+
 ; Calibration build: keya_sim_was + periodic current-byte log so we can
 ; map the raw heartbeat current value to actual amps. KEYA_LOG_CURRENT_EVERY
 ; = 10 means "log every 10th heartbeat" -> ~5Hz log rate at 50Hz heartbeat.

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,26 @@ build_flags =
 	-DKEYA_MOTOR=1
 	-DKEYA_NO_ACK=1
 
+; Indoor bench simulator. Real WAS still drives a kinematic bicycle model
+; at 100Hz; the model synthesizes GPS NMEA + IMU heading so AOG sees a
+; moving virtual tractor. No satellites needed, IMU can stay still.
+[env:esp32-s3_sim]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DSIMULATOR=1
+
+; Keya + simulator. Combine the two when you want to verify the whole
+; AOG -> autosteer -> Keya CAN -> motor loop on the bench.
+[env:esp32-s3_keya_sim]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DSIMULATOR=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,21 @@ build_flags =
 	-DKEYA_WAS=1
 	-DKEYA_SNIFFER=1
 
+; Pure listener: KEYA_SNIFFER=1 + KEYA_LISTEN_ONLY=1. The firmware
+; receives and logs CAN traffic but never transmits, so an external
+; master (Keya ServoCAN tool) can talk to the motor with zero noise
+; from us. Autosteer still computes PWM but it goes nowhere.
+[env:esp32-s3_keya_listen]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DSIMULATOR=1
+	-DKEYA_WAS=1
+	-DKEYA_SNIFFER=1
+	-DKEYA_LISTEN_ONLY=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -81,6 +81,20 @@ build_flags =
 	-DSIMULATOR=1
 	-DKEYA_WAS=1
 
+; Same as keya_sim_was but with KEYA_SNIFFER=1 so KeyaMotor::handler()
+; logs every non-heartbeat CAN frame received. Pair with another CAN
+; master on the bus (Keya ServoCAN configuration tool via Cando_pro,
+; etc.) to reverse-engineer proprietary commands.
+[env:esp32-s3_keya_sim_was_sniff]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DSIMULATOR=1
+	-DKEYA_WAS=1
+	-DKEYA_SNIFFER=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,6 +66,21 @@ build_flags =
 	-DKEYA_MOTOR=1
 	-DSIMULATOR=1
 
+; Full no-external-sensor indoor rig: Keya CAN motor + bicycle simulator
+; for GPS/IMU + Keya encoder used as the WAS source. Useful when no
+; physical wheel-angle sensor is wired - the motor's position is read
+; back as the steering angle (900-deg lock-to-lock range, 1 count/deg).
+; Configure firmware Settings: steerSensorCounts=1, ackerman=100,
+; invertWAS as needed to match motor mounting.
+[env:esp32-s3_keya_sim_was]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DSIMULATOR=1
+	-DKEYA_WAS=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,19 @@ build_flags =
 	-DKEYA_WAS=1
 	-DKEYA_SNIFFER=1
 
+; Calibration build: keya_sim_was + periodic current-byte log so we can
+; map the raw heartbeat current value to actual amps. KEYA_LOG_CURRENT_EVERY
+; = 10 means "log every 10th heartbeat" -> ~5Hz log rate at 50Hz heartbeat.
+[env:esp32-s3_keya_sim_was_calib]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DSIMULATOR=1
+	-DKEYA_WAS=1
+	-DKEYA_LOG_CURRENT_EVERY=10
+
 ; Pure listener: KEYA_SNIFFER=1 + KEYA_LISTEN_ONLY=1. The firmware
 ; receives and logs CAN traffic but never transmits, so an external
 ; master (Keya ServoCAN tool) can talk to the motor with zero noise

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,15 @@ build_flags =
 	-DARDUINO_USB_MODE=1
 	-DGPS_HEADING=1
 
+; Keya CAN motor build. Replaces the PWM motor backend with a Keya CAN driver
+; on the CAN_TX_PIN/CAN_RX_PIN pair. Default GPS layout (single-GPS PCB).
+[env:esp32-s3_keya]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,18 @@ build_flags =
 	-DGPS_HEADING=0
 	-DKEYA_MOTOR=1
 
+; Keya CAN bench-test build. Same as esp32-s3_keya but the TWAI driver runs
+; in NO_ACK mode so a solo board with no other CAN node can still transmit
+; frames for inspection on a sniffer. Engage will refuse (no heartbeat) -
+; this env is for waveform/protocol verification only, not for steering.
+[env:esp32-s3_keya_noack]
+extends = env:esp32-s3
+build_flags =
+	-DARDUINO_USB_MODE=1
+	-DGPS_HEADING=0
+	-DKEYA_MOTOR=1
+	-DKEYA_NO_ACK=1
+
 ; Serial-flash environment - use when the S3's USB-CDC has taken over the
 ; native USB and esp-builtin JTAG can't open the device. Put the board into
 ; download mode (hold BOOT, tap RESET) before running.

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -8,6 +8,9 @@
 #include "imu.h"
 #include "config/defines.h"
 #include "config/constants.h"
+#if KEYA_MOTOR
+#include "hardware/motor/keya_motor.h"
+#endif
 
 namespace autosteer {
 bool prevSteerEnable = false;
@@ -39,7 +42,20 @@ void handler() {
     bool reversed = control_out < 0;
 
     if (steerEnable) {
+#if KEYA_MOTOR
+        if (!hw::KeyaMotor::isHealthy()) {
+            static unsigned long lastKeyaWarn = 0;
+            if (millis() - lastKeyaWarn > 1000) {
+                error("Keya motor unhealthy (no heartbeat or fault) - refusing engage");
+                lastKeyaWarn = millis();
+            }
+            motor::stopMotor();
+        } else {
+            motor::driveMotor(pwm, reversed);
+        }
+#else
         motor::driveMotor(pwm, reversed); //out to motors the pwm value
+#endif
     } else {
         motor::stopMotor();
         pulseCount = 0; //Reset counters if Autosteer is offline

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -33,21 +33,32 @@ void handler() {
     // Overcurrent override is gated on the AOG-side "Current sensor" or
     // "Pressure sensor" steerConfig bit (PGN 251 setting1 bits 1/2). The
     // threshold is taken from PGN 251 byte 6 (pulseCountMax) which AOG's
-    // GUI exposes as the "Steer Wheel Encoder" / "max sensor reading" field
-    // - the same field the Teensy reference uses for this. Heartbeat current
-    // is 1 A per LSB so pulseCountMax * 1000 mA is the trip level. If the
-    // user enables the sensor bit but leaves the threshold at 0, fall back
-    // to the compile-time KEYA_OVERCURRENT_TRIP_MA so the feature still
-    // works without an explicit AOG configuration.
+    // GUI exposes as a "max sensor reading" field, in the SAME unit AOG
+    // displays the live value (PGN 250 byte 5 = sensorData). We send
+    // sensorData as deciAmps (0.1 A per LSB), so when AOG shows "66" the
+    // motor is at 6.6 A and a "41" threshold fires at 4.1 A. We therefore
+    // compare in deciAmps directly - the trip level the user types in AOG
+    // is exactly the displayed value. If the user enables the sensor bit
+    // but leaves the threshold at 0, fall back to the compile-time
+    // KEYA_OVERCURRENT_TRIP_MA so the feature still works on a fresh
+    // setup before AOG has been configured.
     if (steerEnable && !overcurrentLatched
             && (Set.currentSensor || Set.pressureSensor)) {
-        uint16_t threshold_mA = (Set.pulseCountMax > 0)
-                                ? (uint16_t)Set.pulseCountMax * 1000
-                                : KEYA_OVERCURRENT_TRIP_MA;
         uint16_t now_mA = hw::KeyaMotor::getCurrentMA();
-        if (now_mA >= threshold_mA) {
-            errorf("Keya overcurrent override: %u mA >= %u mA - disengaging",
-                   now_mA, threshold_mA);
+        // Scale to the same 0..255 byte AOG uses for display + threshold,
+        // so pulseCountMax (the AOG-set trip level) compares directly with
+        // the live value AOG sees. 1 byte = KEYA_AOG_MA_PER_BYTE mA, so
+        // 17 A peak <-> byte 230 <-> AOG "90%".
+        uint16_t now_byte = ((uint32_t)now_mA + KEYA_AOG_MA_PER_BYTE / 2)
+                            / KEYA_AOG_MA_PER_BYTE;
+        if (now_byte > 255) now_byte = 255;
+        uint16_t threshold_byte = (Set.pulseCountMax > 0)
+            ? Set.pulseCountMax
+            : ((KEYA_OVERCURRENT_TRIP_MA + KEYA_AOG_MA_PER_BYTE / 2)
+               / KEYA_AOG_MA_PER_BYTE);
+        if (now_byte >= threshold_byte) {
+            errorf("Keya overcurrent override: byte %u >= %u (%u mA) - disengaging",
+                   now_byte, threshold_byte, now_mA);
             overcurrentLatched = true;
         }
     }

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -27,6 +27,17 @@ void handler() {
 
     if (steerEnable != prevSteerEnable) {
         debugf("Steer enable state changed: %s", steerEnable ? "enabled" : "disabled");
+#if KEYA_MOTOR
+        if (steerEnable) {
+            // Engaging - start a fresh peak window so we can see the
+            // worst-case current during just this engaged session.
+            hw::KeyaMotor::resetPeakCurrent();
+        } else {
+            // Disengaging - report what the motor pulled at its worst.
+            infof("Keya: peak current during engage = %u mA",
+                  hw::KeyaMotor::getPeakCurrentMA());
+        }
+#endif
         prevSteerEnable = steerEnable;
     }
 

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -16,14 +16,50 @@ namespace autosteer {
 bool prevSteerEnable = false;
 bool steerEnable     = false;
 int pulseCount       = 0; //TODO:IMPLEMENT ENCODER
+
+#if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
+// Latched override - once tripped, autosteer refuses to re-engage until
+// AOG drops guidance status (which clears the latch on the next disengage).
+// The Keya controller already filters its current reading internally
+// (through its current-loop PI regulator) so we use the raw heartbeat
+// value directly without additional smoothing.
+static bool overcurrentLatched = false;
+#endif
+
 void handler() {
     bool hwEnable = buttons::steerBntEnabled();
     bool swEnable = getSwSwitchStatus();
-    if (hwEnable && swEnable) {
+
+#if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
+    // While engaged, watch for the override.
+    if (steerEnable && !overcurrentLatched) {
+        uint16_t now_mA = hw::KeyaMotor::getCurrentMA();
+        if (now_mA >= KEYA_OVERCURRENT_TRIP_MA) {
+            errorf("Keya overcurrent override: %u mA >= %d mA - disengaging",
+                   now_mA, KEYA_OVERCURRENT_TRIP_MA);
+            overcurrentLatched = true;
+        }
+    }
+#endif
+
+    if (hwEnable && swEnable
+#if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
+            && !overcurrentLatched
+#endif
+        ) {
         steerEnable = true;
     } else {
         steerEnable = false;
     }
+
+#if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
+    // Clear the latch on any deliberate user disengage - either dropping the
+    // AOG software switch OR releasing the physical steer switch/button. That
+    // way the user can re-arm after a fault from whichever input they normally
+    // use, regardless of the configured steer_switch_type. The latch survives
+    // a single engaged session, then clears.
+    if (!hwEnable || !swEnable) overcurrentLatched = false;
+#endif
 
     if (steerEnable != prevSteerEnable) {
         debugf("Steer enable state changed: %s", steerEnable ? "enabled" : "disabled");

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -19,10 +19,9 @@ int pulseCount       = 0; //TODO:IMPLEMENT ENCODER
 
 #if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
 // Latched override - once tripped, autosteer refuses to re-engage until
-// AOG drops guidance status (which clears the latch on the next disengage).
-// The Keya controller already filters its current reading internally
-// (through its current-loop PI regulator) so we use the raw heartbeat
-// value directly without additional smoothing.
+// the user releases the engage input. The Keya controller already filters
+// its current reading internally (through its current-loop PI regulator)
+// so we use the raw heartbeat value directly without additional smoothing.
 static bool overcurrentLatched = false;
 #endif
 
@@ -31,8 +30,12 @@ void handler() {
     bool swEnable = getSwSwitchStatus();
 
 #if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
-    // While engaged, watch for the override.
-    if (steerEnable && !overcurrentLatched) {
+    // Overcurrent override is gated on the AOG-side "Current sensor" or
+    // "Pressure sensor" steerConfig bit (PGN 251 setting1). If the user has
+    // neither enabled, this whole feature is silent. Honors the same bit
+    // the Teensy reference uses, so AOG's existing toggle works.
+    if (steerEnable && !overcurrentLatched
+            && (Set.currentSensor || Set.pressureSensor)) {
         uint16_t now_mA = hw::KeyaMotor::getCurrentMA();
         if (now_mA >= KEYA_OVERCURRENT_TRIP_MA) {
             errorf("Keya overcurrent override: %u mA >= %d mA - disengaging",
@@ -115,5 +118,10 @@ void handler() {
 // Get the combined steer switch state (physical button and software switch) TODO: what is correct operation? include sw switch?
 bool getSteerSwitchState() {
     return buttons::steerBntEnabled();
+}
+
+// Actual autosteer engagement state, including any firmware-side overrides.
+bool isEngaged() {
+    return steerEnable;
 }
 }

--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -31,15 +31,23 @@ void handler() {
 
 #if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
     // Overcurrent override is gated on the AOG-side "Current sensor" or
-    // "Pressure sensor" steerConfig bit (PGN 251 setting1). If the user has
-    // neither enabled, this whole feature is silent. Honors the same bit
-    // the Teensy reference uses, so AOG's existing toggle works.
+    // "Pressure sensor" steerConfig bit (PGN 251 setting1 bits 1/2). The
+    // threshold is taken from PGN 251 byte 6 (pulseCountMax) which AOG's
+    // GUI exposes as the "Steer Wheel Encoder" / "max sensor reading" field
+    // - the same field the Teensy reference uses for this. Heartbeat current
+    // is 1 A per LSB so pulseCountMax * 1000 mA is the trip level. If the
+    // user enables the sensor bit but leaves the threshold at 0, fall back
+    // to the compile-time KEYA_OVERCURRENT_TRIP_MA so the feature still
+    // works without an explicit AOG configuration.
     if (steerEnable && !overcurrentLatched
             && (Set.currentSensor || Set.pressureSensor)) {
+        uint16_t threshold_mA = (Set.pulseCountMax > 0)
+                                ? (uint16_t)Set.pulseCountMax * 1000
+                                : KEYA_OVERCURRENT_TRIP_MA;
         uint16_t now_mA = hw::KeyaMotor::getCurrentMA();
-        if (now_mA >= KEYA_OVERCURRENT_TRIP_MA) {
-            errorf("Keya overcurrent override: %u mA >= %d mA - disengaging",
-                   now_mA, KEYA_OVERCURRENT_TRIP_MA);
+        if (now_mA >= threshold_mA) {
+            errorf("Keya overcurrent override: %u mA >= %u mA - disengaging",
+                   now_mA, threshold_mA);
             overcurrentLatched = true;
         }
     }

--- a/src/autosteer/autosteer.h
+++ b/src/autosteer/autosteer.h
@@ -4,7 +4,16 @@
 namespace autosteer {
 void handler();
 
-// Get the combined steer switch state (physical button and software switch)
+// Get the combined steer switch state (physical button and software switch).
+// Reflects user intent only - does NOT account for firmware-side overrides
+// (overcurrent latch etc.). Used for HelloReply where AOG wants to know the
+// switch position regardless of any firmware fault state.
 bool getSteerSwitchState();
+
+// Get the actual autosteer engagement state. True only when user intent is
+// engaged AND no firmware-side override has fired. This is what we report
+// in PGN 253 byte 11 so AOG's GUI accurately reflects whether the motor is
+// being driven.
+bool isEngaged();
 }
 #endif // STEERING_CONTROL_H

--- a/src/autosteer/autosteer_config.h
+++ b/src/autosteer/autosteer_config.h
@@ -6,7 +6,13 @@
 #define AUTOSTEER_CONFIG_H
 
 #define LOW_HIGH_DEGREES 3.0
-#define WATCHDOG_TIMEOUT 200 // Watchdog timeout in milliseconds
+// Watchdog timeout in ms. AOG SteerData arrives at ~10Hz (~100ms cadence);
+// 200ms was too tight - normal UDP jitter would push one packet past that
+// and disengage autosteer (resetting NONE-mode arming in the process,
+// requiring AOG to toggle status off->on again). 500ms tolerates ~5
+// missed packets - generous against jitter, still short enough to catch
+// a real AOG outage promptly.
+#define WATCHDOG_TIMEOUT 500
 
 
 #endif //AUTOSTEER_CONFIG_H

--- a/src/autosteer/settings.cpp
+++ b/src/autosteer/settings.cpp
@@ -82,12 +82,12 @@ void parse() {
     bool steerButton      = (config.setting0 >> 6) & 0x01;
     Set.steer_switch_type = steerSwitch ? steer_switch_type_types::SWITCH : steerButton ? steer_switch_type_types::BUTTON : steer_switch_type_types::NONE;
 
-    //TODO:implement encoDer and pressure sensor
+    //TODO:implement encoder
     bool shaftEncoder  = (config.setting0 >> 7) & 0x01;
-    auto pulseCountMax = config.pulseCountMax;
+    Set.pulseCountMax  = config.pulseCountMax;
 // WAS Speed config_packet.was_speed
-    bool pressure_sensor = (config.setting1 >> 1) & 0x01;
-    bool current_sensor  = (config.setting1 >> 2) & 0x01;
+    Set.pressureSensor = (config.setting1 >> 1) & 0x01;
+    Set.currentSensor  = (config.setting1 >> 2) & 0x01;
     //TODO: implement switching IMU axis
     bool is_use_y_axis = (config.setting1 >> 3) & 0x01;
 }
@@ -110,6 +110,9 @@ void printSettings() {
     debugf("Steer Switch: %d", Set.steer_switch_type == steer_switch_type_types::SWITCH);
     debugf("Steer Button: %d", Set.steer_switch_type == steer_switch_type_types::BUTTON);
     debugf("Shaft Encoder: %d", Set.wasType == WASType::single);
+    debugf("Pressure Sensor: %d", Set.pressureSensor);
+    debugf("Current Sensor: %d", Set.currentSensor);
+    debugf("PulseCountMax: %d", Set.pulseCountMax);
     debug("################################");
 }
 

--- a/src/autosteer/settings.cpp
+++ b/src/autosteer/settings.cpp
@@ -38,11 +38,16 @@ static bool validateSettings(SteerSettings& s, SteerConfig& c) {
         valid = false;
     }
 
-    // Validate Ackerman fix (prevent division issues, reasonable range)
-    if (c.pulseCountMax < MIN_ACKERMAN_FIX || c.pulseCountMax > MAX_ACKERMAN_FIX) {
+    // Validate Ackerman fix (prevent division issues, reasonable range).
+    // Note: this used to check c.pulseCountMax (PGN 251 byte 6) but ackerman
+    // actually lives in s.ackermanFix (PGN 252 byte 12). The old check
+    // clobbered pulseCountMax with 100 every boot, breaking any AOG-set
+    // override threshold and producing the "Ackerman fix out of range"
+    // warning that fired on every fresh EEPROM regardless of state.
+    if (s.ackermanFix < MIN_ACKERMAN_FIX || s.ackermanFix > MAX_ACKERMAN_FIX) {
         warningf("Ackerman fix out of range (%d-%d), using %d",
                  MIN_ACKERMAN_FIX, MAX_ACKERMAN_FIX, DEFAULT_ACKERMAN_FIX);
-        c.pulseCountMax = DEFAULT_ACKERMAN_FIX;
+        s.ackermanFix = DEFAULT_ACKERMAN_FIX;
         valid = false;
     }
 

--- a/src/autosteer/settings.h
+++ b/src/autosteer/settings.h
@@ -47,6 +47,17 @@ struct Storage {
     WASType wasType;
     DriverType driverType;
     steer_switch_type_types steer_switch_type;
+
+    // Manual-override sensors (PGN 251 setting1 bits 1 & 2). When either is
+    // set, autosteer uses motor load (or analog sensor) crossing
+    // pulseCountMax to force-disengage. With KEYA_MOTOR=1 the load comes
+    // from heartbeat current; otherwise from the analog MOTOR_CURRENT_PIN.
+    bool pressureSensor;
+    bool currentSensor;
+
+    // Threshold (PGN 251 byte 6, "pulseCountMax"). Reused by Teensy/Keya
+    // forks as the overcurrent / pressure trip level.
+    uint8_t pulseCountMax;
 };
 
 // Global settings instance

--- a/src/autosteer/udp_io.cpp
+++ b/src/autosteer/udp_io.cpp
@@ -207,12 +207,28 @@ void processReceivedPacket(const uint8_t *data, size_t len, ip_address sourceIP)
 
                 // Extract and convert values
                 gpsSpeed           = static_cast<float>(steerData->speed) * 0.1f;
-                guidanceStatus     = steerData->status & 0x01;
+                uint8_t newGuidanceStatus = steerData->status & 0x01;
 
                 // Decode steering angle (int16_t encoded as uint16_t * scale factor)
                 // Protocol encodes angles as int16 * 100
                 int16_t raw_angle = static_cast<int16_t>(steerData->steerAngle);
-                steerAngleSetPoint = static_cast<float>(raw_angle) * ANGLE_SCALE_FACTOR;
+                float newSetpoint = static_cast<float>(raw_angle) * ANGLE_SCALE_FACTOR;
+
+                // Log transitions of guidanceStatus and "significant" setpoint
+                // changes (>0.1 deg) so we can see what AOG is asking for
+                // without spamming the debug stream every 100ms.
+                if (newGuidanceStatus != guidanceStatus) {
+                    infof("AOG: guidanceStatus -> %u (setpoint=%.2f deg)",
+                          (unsigned)newGuidanceStatus, (double)newSetpoint);
+                }
+                if (fabsf(newSetpoint - steerAngleSetPoint) > 0.1f) {
+                    debugf("AOG: setpoint=%.2f deg (status=%u, speed=%.1f)",
+                           (double)newSetpoint, (unsigned)newGuidanceStatus,
+                           (double)gpsSpeed);
+                }
+
+                guidanceStatus     = newGuidanceStatus;
+                steerAngleSetPoint = newSetpoint;
 
                 // Validate angle is within expected range
                 if (steerAngleSetPoint < MIN_STEER_ANGLE_DEG || steerAngleSetPoint > MAX_STEER_ANGLE_DEG) {

--- a/src/autosteer/udp_io.cpp
+++ b/src/autosteer/udp_io.cpp
@@ -350,7 +350,10 @@ void sendSteerData() {
     float actualSteerAngle = was::get_steering_angle();
     float heading = imu::get_heading();
     float roll = imu::get_roll();
-    bool steer_switch = buttons::steerBntEnabled();
+    // Report the actual autosteer engagement state to AOG (not just the raw
+    // button), so an internal force-disengage (overcurrent trip, fault, etc.)
+    // is visible on the GUI side and AOG knows we are no longer steering.
+    bool steer_switch = autosteer::isEngaged();
     bool work_switch = buttons::workBntEnabled();
     uint8_t pwmDisplay = motor::getCurrentPWM();
 

--- a/src/autosteer/udp_io.cpp
+++ b/src/autosteer/udp_io.cpp
@@ -9,6 +9,9 @@
 #include "motor.h"
 #include "settings.h"
 #include "utils/log.h"
+#if KEYA_MOTOR
+#include "hardware/motor/keya_motor.h"
+#endif
 
 // Global variables
 uint32_t lastDataReceived                  = 0;
@@ -350,7 +353,19 @@ void sendSteerData() {
     bool steer_switch = buttons::steerBntEnabled();
     bool work_switch = buttons::workBntEnabled();
     uint8_t pwmDisplay = motor::getCurrentPWM();
+
+    // FROM_AUTOSTEER2 byte 5 ("sensorValue" / AOG mc.sensorData). On Keya
+    // builds, fill it with the live motor current scaled to 0.1 A per unit
+    // (0..255 = 0..25.5 A), which covers the KY173 17 A peak with headroom.
+    // On non-Keya builds, fall back to the raw WAS reading like upstream
+    // AOG firmware (used for WAS calibration views in some forks).
+#if KEYA_MOTOR
+    uint16_t curMA = hw::KeyaMotor::getCurrentMA();
+    uint16_t deciAmps = (curMA + 50) / 100; // round-half-up to 0.1 A
+    uint8_t sensorValue = (deciAmps > 255) ? 255 : (uint8_t)deciAmps;
+#else
     uint8_t sensorValue = was::get_wheel_angle_sensor_raw();
+#endif
 
     debugf("Sending response: A=%.2f, R=%d, H=%.1f, R=%.1f, S=%d, pwm=%d",
            actualSteerAngle, was::get_raw_steering_position(), heading, roll, steer_switch, pwmDisplay);

--- a/src/autosteer/udp_io.cpp
+++ b/src/autosteer/udp_io.cpp
@@ -358,14 +358,17 @@ void sendSteerData() {
     uint8_t pwmDisplay = motor::getCurrentPWM();
 
     // FROM_AUTOSTEER2 byte 5 ("sensorValue" / AOG mc.sensorData). On Keya
-    // builds, fill it with the live motor current scaled to 0.1 A per unit
-    // (0..255 = 0..25.5 A), which covers the KY173 17 A peak with headroom.
+    // builds, scale the live motor current so the motor's 17 A peak rating
+    // lands at AOG's 90% display (byte ~230). 1 byte = KEYA_AOG_MA_PER_BYTE
+    // mA. AOG truncates display via floor(byte * 100/255), so this scaling
+    // gives the user a meaningful percentage where 90% means "at peak".
     // On non-Keya builds, fall back to the raw WAS reading like upstream
     // AOG firmware (used for WAS calibration views in some forks).
 #if KEYA_MOTOR
     uint16_t curMA = hw::KeyaMotor::getCurrentMA();
-    uint16_t deciAmps = (curMA + 50) / 100; // round-half-up to 0.1 A
-    uint8_t sensorValue = (deciAmps > 255) ? 255 : (uint8_t)deciAmps;
+    uint32_t scaled = ((uint32_t)curMA + KEYA_AOG_MA_PER_BYTE / 2)
+                      / KEYA_AOG_MA_PER_BYTE;
+    uint8_t sensorValue = (scaled > 255) ? 255 : (uint8_t)scaled;
 #else
     uint8_t sensorValue = was::get_wheel_angle_sensor_raw();
 #endif

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -1,6 +1,20 @@
 #ifndef DEFINES_H
 #define DEFINES_H
 
+// Hardware test mode. When 1:
+//  - hw::init() does not halt on missing peripherals; failures become
+//    warnings so the firmware boots with whatever subset of hardware is
+//    physically present (useful for validating IMU, GPS, WAS, motor
+//    independently without needing the rest plugged in).
+//  - A test task logs the live state of every subsystem at 1 Hz on the
+//    UDP debug stream so the user can see at a glance which one is
+//    responding.
+//  - Autosteer remains running but the motor will no-op cleanly if its
+//    init failed.
+#ifndef TEST_MODE
+#define TEST_MODE 0
+#endif
+
 #define FIRMWARE_VERSION "0.0.1"
 #define BUILD_DATE __DATE__ " " __TIME__
 

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -28,6 +28,15 @@
 #define KEYA_NO_ACK 0
 #endif
 
+// CAN sniffer mode. When set, KeyaMotor::handler() logs every received CAN
+// frame (other than the regular heartbeat) over the UDP debug stream as
+// raw hex, including frames we do not normally recognize. Use with another
+// CAN master on the same bus (Keya ServoCAN tool, etc.) to reverse-engineer
+// proprietary commands the motor responds to.
+#ifndef KEYA_SNIFFER
+#define KEYA_SNIFFER 0
+#endif
+
 // Virtual WAS sourced from the Keya motor's encoder position. When 1, the
 // firmware skips ADS1115WAS and registers a shim that reads cumulative
 // degrees from the Keya heartbeat. Useful when there is no physical wheel-

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -46,6 +46,20 @@
 #define KEYA_LISTEN_ONLY 0
 #endif
 
+// Overcurrent-based manual-override disengagement. When the smoothed motor
+// current crosses this threshold during an engaged session, autosteer
+// force-disengages and refuses to re-engage until AOG cycles guidanceStatus.
+// Mirrors the Teensy-Keya fork's PressureSensor / pulseCount override
+// pattern (Autosteer.ino sec 4.4) but uses the heartbeat current value
+// directly so no analog sensor is needed. 0 disables.
+//
+// 6000 mA is roughly 3-4x typical autosteer current, well below the motor's
+// 17A max - generous enough that normal hard turns don't false-trigger but
+// catches a wheel-grab before the supply undervoltage trips.
+#ifndef KEYA_OVERCURRENT_TRIP_MA
+#define KEYA_OVERCURRENT_TRIP_MA 6000
+#endif
+
 // Virtual WAS sourced from the Keya motor's encoder position. When 1, the
 // firmware skips ADS1115WAS and registers a shim that reads cumulative
 // degrees from the Keya heartbeat. Useful when there is no physical wheel-

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -28,6 +28,26 @@
 #define KEYA_NO_ACK 0
 #endif
 
+// Virtual WAS sourced from the Keya motor's encoder position. When 1, the
+// firmware skips ADS1115WAS and registers a shim that reads cumulative
+// degrees from the Keya heartbeat. Useful when there is no physical wheel-
+// angle sensor wired but a Keya motor is mechanically coupled to the
+// steering shaft. Requires KEYA_MOTOR=1.
+#ifndef KEYA_WAS
+#define KEYA_WAS 0
+#endif
+
+// Total mechanical range of the steering shaft in degrees (lock-to-lock).
+// The KeyaWAS shim clamps the cumulative reading to +-(KEYA_WAS_RANGE_DEG/2)
+// so a runaway encoder cannot blow up downstream math. 900 = +-450 deg.
+#define KEYA_WAS_RANGE_DEG 900
+
+// Counts per degree reported by the KeyaWAS shim. The Keya heartbeat is 1
+// LSB per degree, so 1 count/deg preserves resolution exactly. The user
+// must set the firmware Settings::steerSensorCounts to match this so
+// was::get_steering_angle() returns degrees correctly.
+#define KEYA_WAS_COUNTS_PER_DEG 1
+
 // Bench simulator: kinematic bicycle model that consumes the real WAS reading
 // and synthesizes GPS NMEA + IMU heading. Lets the device run end-to-end
 // indoors with no satellites and a stationary IMU. 0 = real sensors, 1 = sim.

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -38,15 +38,21 @@
 #endif
 
 // Total mechanical range of the steering shaft in degrees (lock-to-lock).
-// The KeyaWAS shim clamps the cumulative reading to +-(KEYA_WAS_RANGE_DEG/2)
-// so a runaway encoder cannot blow up downstream math. 900 = +-450 deg.
+// 900 means the encoder can rotate +-450 deg from the boot position.
 #define KEYA_WAS_RANGE_DEG 900
 
-// Counts per degree reported by the KeyaWAS shim. The Keya heartbeat is 1
-// LSB per degree, so 1 count/deg preserves resolution exactly. The user
-// must set the firmware Settings::steerSensorCounts to match this so
-// was::get_steering_angle() returns degrees correctly.
-#define KEYA_WAS_COUNTS_PER_DEG 1
+// Half-range of the synthesized WAS *output* angle in degrees - i.e. the
+// peak wheel-angle equivalent at full lock. With KEYA_WAS_RANGE_DEG=900
+// (encoder +-450 deg) and KEYA_WAS_OUT_HALF_DEG=45, full lock encoder
+// rotation maps to +-45 deg of reported wheel angle (a 10:1 reduction
+// from steering shaft to wheel - typical for a small tractor with a
+// reasonable Pitman arm).
+#define KEYA_WAS_OUT_HALF_DEG 45
+
+// Raw counts per degree of WAS output. The was.cpp pipeline divides the
+// raw int16 by Settings.steerSensorCounts to get degrees, so this value
+// must match steerSensorCounts on the AOG side (default 100).
+#define KEYA_WAS_COUNTS_PER_OUT_DEG 100
 
 // Bench simulator: kinematic bicycle model that consumes the real WAS reading
 // and synthesizes GPS NMEA + IMU heading. Lets the device run end-to-end

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -46,18 +46,39 @@
 #define KEYA_LISTEN_ONLY 0
 #endif
 
-// Overcurrent-based manual-override disengagement. When the smoothed motor
-// current crosses this threshold during an engaged session, autosteer
-// force-disengages and refuses to re-engage until AOG cycles guidanceStatus.
-// Mirrors the Teensy-Keya fork's PressureSensor / pulseCount override
-// pattern (Autosteer.ino sec 4.4) but uses the heartbeat current value
-// directly so no analog sensor is needed. 0 disables.
+// Conversion factor from the raw heartbeat current value (bytes 4-5, signed
+// int16 BE per manual sec 4.5.2) to milliamps. The manual does not document
+// the unit. Working hypothesis based on bench observation: 1 raw unit = 1 A,
+// so 17 A peak = raw 17, and KEYA_CURRENT_RAW_PER_MA = 1000.
 //
-// 6000 mA is roughly 3-4x typical autosteer current, well below the motor's
-// 17A max - generous enough that normal hard turns don't false-trigger but
-// catches a wheel-grab before the supply undervoltage trips.
+// To verify: enable KEYA_LOG_CURRENT_EVERY, stall the motor at a known load
+// (or just hold the wheel), and confirm the raw values you see line up.
+// Update this constant if the controller turns out to use a different scale.
+#ifndef KEYA_CURRENT_RAW_PER_MA
+#define KEYA_CURRENT_RAW_PER_MA 1000
+#endif
+
+// Periodic logging of raw heartbeat current bytes during engaged operation.
+// 0 = silent, N = log every Nth heartbeat (~50 Hz cadence so N=10 -> 5 Hz
+// log rate). Useful for calibrating KEYA_CURRENT_RAW_PER_MA.
+#ifndef KEYA_LOG_CURRENT_EVERY
+#define KEYA_LOG_CURRENT_EVERY 0
+#endif
+
+// Overcurrent-based manual-override disengagement. When the heartbeat motor
+// current crosses this threshold during an engaged session, autosteer
+// force-disengages and refuses to re-engage until the user releases the
+// engage input. Mirrors the Teensy-Keya fork's PressureSensor / pulseCount
+// override pattern (Autosteer.ino sec 4.4) but uses the heartbeat current
+// value directly so no analog sensor is needed. 0 disables.
+//
+// Bench observation: heartbeat resolution is 1 A per LSB. The motor's spec
+// is 10 A continuous / 17 A peak. We pick 12 A (12000 mA) as a default -
+// just above continuous so legitimate hard turns don't false-trigger, but
+// well below the motor's own 17 A internal trip so we disengage cleanly
+// before the motor faults itself.
 #ifndef KEYA_OVERCURRENT_TRIP_MA
-#define KEYA_OVERCURRENT_TRIP_MA 6000
+#define KEYA_OVERCURRENT_TRIP_MA 12000
 #endif
 
 // Virtual WAS sourced from the Keya motor's encoder position. When 1, the

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -37,6 +37,15 @@
 #define KEYA_SNIFFER 0
 #endif
 
+// Listen-only mode. When set, KeyaMotor never transmits (no speed, no
+// enable, no disable, no keep-alive). Pair with KEYA_SNIFFER=1 so the
+// firmware silently observes whatever another master on the bus does -
+// no risk of our own ACKs cluttering the log or the motor reacting to
+// our commands. Autosteer still computes PWM but it goes nowhere.
+#ifndef KEYA_LISTEN_ONLY
+#define KEYA_LISTEN_ONLY 0
+#endif
+
 // Virtual WAS sourced from the Keya motor's encoder position. When 1, the
 // firmware skips ADS1115WAS and registers a shim that reads cumulative
 // degrees from the Keya heartbeat. Useful when there is no physical wheel-

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -15,6 +15,19 @@
 #define GPS_HEADING 0
 #endif
 
+// Motor backend selection. 0 = PWM (Cytron/Danfoss-style), 1 = Keya CAN bus.
+// Override per-environment via platformio.ini build_flags (-DKEYA_MOTOR=1).
+#ifndef KEYA_MOTOR
+#define KEYA_MOTOR 0
+#endif
+
+// Bench-test affordance: when set, the TWAI driver runs in NO_ACK mode so a
+// solo ESP32 with no other CAN node on the bus can still transmit frames for
+// inspection on a sniffer. Off in production - leave at 0 unless debugging.
+#ifndef KEYA_NO_ACK
+#define KEYA_NO_ACK 0
+#endif
+
 #define STATIC_IP_ADDR {192, 168, 178, 126}
 #define STATIC_GW_ADDR {192, 168, 178, 1}
 #define STATIC_SN_ADDR {255, 255, 255, 0}
@@ -39,6 +52,7 @@
 #define IMU_TASK_PRIORITY 3
 #define GPS_TASK_PRIORITY (10)
 #define HEADING_TASK_PRIORITY (10)
+#define KEYA_TASK_PRIORITY 3
 
 
 #define AgOpenGPS_UDP_PORT 9999

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -28,6 +28,19 @@
 #define KEYA_NO_ACK 0
 #endif
 
+// Bench simulator: kinematic bicycle model that consumes the real WAS reading
+// and synthesizes GPS NMEA + IMU heading. Lets the device run end-to-end
+// indoors with no satellites and a stationary IMU. 0 = real sensors, 1 = sim.
+#ifndef SIMULATOR
+#define SIMULATOR 0
+#endif
+#define SIM_WHEELBASE_M   2.5f
+#define SIM_SPEED_MPS     1.5f
+#define SIM_INIT_LAT      60.50000
+#define SIM_INIT_LON      22.50000
+#define SIM_TICK_MS       10
+#define SIM_NMEA_DIVIDER  10
+
 #define STATIC_IP_ADDR {192, 168, 178, 126}
 #define STATIC_GW_ADDR {192, 168, 178, 1}
 #define STATIC_SN_ADDR {255, 255, 255, 0}
@@ -53,6 +66,7 @@
 #define GPS_TASK_PRIORITY (10)
 #define HEADING_TASK_PRIORITY (10)
 #define KEYA_TASK_PRIORITY 3
+#define SIM_TASK_PRIORITY  4
 
 
 #define AgOpenGPS_UDP_PORT 9999

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -58,6 +58,16 @@
 #define KEYA_CURRENT_RAW_PER_MA 1000
 #endif
 
+// Milliamps per byte for the value reported in PGN 250 byte 5 (sensorData)
+// and used as the threshold from PGN 251 byte 6 (pulseCountMax). AOG's GUI
+// truncates the byte to a percent via floor(byte * 100/255); for the
+// KY173's 17 A peak rating to land at 90% AOG display we want byte = 230,
+// so 1 byte = 17000/230 ~= 74 mA. Byte 255 then represents ~18.9 A
+// (slightly above peak), giving a small headroom above spec for transients.
+#ifndef KEYA_AOG_MA_PER_BYTE
+#define KEYA_AOG_MA_PER_BYTE 74
+#endif
+
 // Periodic logging of raw heartbeat current bytes during engaged operation.
 // 0 = silent, N = log every Nth heartbeat (~50 Hz cadence so N=10 -> 5 Hz
 // log rate). Useful for calibrating KEYA_CURRENT_RAW_PER_MA.

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -162,6 +162,14 @@
 
 #define GPS_DEFAULT_CONFIGURATION false
 
+// Main GPS navigation rate in Hz. The u-blox is set to this on every boot
+// (RAM only - the module's permanent configuration is left alone). 10 Hz
+// is the standard AgOpenGPS rate. Range typically 1..25 depending on the
+// chipset and which constellations are enabled.
+#ifndef GPS_NAV_FREQ_HZ
+#define GPS_NAV_FREQ_HZ 10
+#endif
+
 #define BUTTONS_TASK_PRIORITY 6
 #define WAS_TASK_PRIORITY 4
 #define AUTOSTEER_TASK_PRIORITY 5

--- a/src/config/pinout.h
+++ b/src/config/pinout.h
@@ -34,6 +34,11 @@
 #define W6100_MOSI_GPIO 17
 #define W6100_INT_GPIO 6
 
+// CAN bus pins (Keya motor). The CAN transceiver's D (driver/TX-in) connects
+// to CAN_TX_PIN; its R (receiver/RX-out) connects to CAN_RX_PIN.
+#define CAN_TX_PIN 21
+#define CAN_RX_PIN 47
+
 //#define LED1_GPIO 41
 //#define LED2_GPIO 42
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -5,6 +5,7 @@
 #include "WebServer_ESP32_SC_W6100.h"
 #include "network/udp.h"
 #include "network/ota.h"
+#include "network/safe_mode.h"
 #include "../hardware/i2c_manager.h"
 #include "hardware/hardware.h"
 #include "tasks.h"
@@ -29,6 +30,15 @@ void setup() {
   // hw::init() can still be recovered remotely.
   initOTA();
 
+  // Crash-recovery hatch. If the previous boot ended in a panic / watchdog
+  // / brownout, or if the user sends a HALT packet in the next ~1.5s, skip
+  // hardware init and task creation entirely - sit in OTA-only loop so a
+  // fix can be pushed remotely without needing JTAG.
+  safe_mode::checkAtBoot();
+  if (safe_mode::active()) {
+    return; // loop() will run handleOTA() + heartbeat forever
+  }
+
   if (!hw::init()) {
     error("FATAL: Hardware initialization failed! Halted (OTA still active).");
     while(1) {
@@ -50,6 +60,12 @@ void setup() {
 
 void loop() {
   handleOTA();
+
+  if (safe_mode::active()) {
+    safe_mode::tickHeartbeat();
+    delay(10);
+    return;
+  }
 
   // Periodic stack monitoring (every 10 seconds)
   static unsigned long lastStackCheck = 0;

--- a/src/gps/gps_module.cpp
+++ b/src/gps/gps_module.cpp
@@ -57,6 +57,41 @@ bool configureGPS() {
     GPSSerial.begin(selected_baud, SERIAL_8N1, MAIN_GPS_RX_PIN, MAIN_GPS_TX_PIN);
     resp = mainGNSS.begin(GPSSerial, defaultMaxWait, false);
 
+    // Set the navigation update rate. RAM only - leaves the module's saved
+    // configuration intact, so the change reverts on power cycle (we just
+    // re-apply it next boot). AOG expects 10 Hz by default.
+    if (resp) {
+        if (mainGNSS.setNavigationFrequency(GPS_NAV_FREQ_HZ)) {
+            debugf("MAIN_GPS - navigation rate set to %d Hz", GPS_NAV_FREQ_HZ);
+        } else {
+            warningf("MAIN_GPS - failed to set navigation rate to %d Hz", GPS_NAV_FREQ_HZ);
+        }
+
+        // Pull and log the live configuration the u-blox is now running, so
+        // we can verify it matches what we requested + see what the user
+        // configured manually via u-center. NMEA message rates are per-port:
+        // we read UART1 (the port talking to us).
+        uint8_t  navFreqHz = mainGNSS.getNavigationFrequency();
+        uint16_t measRate  = mainGNSS.getMeasurementRate();   // ms between fixes
+        uint16_t navRate   = mainGNSS.getNavigationRate();    // cycles per fix
+        uint8_t  protoVer  = mainGNSS.getProtocolVersionHigh();
+        uint8_t  protoMin  = mainGNSS.getProtocolVersionLow();
+        info("---- MAIN_GPS configuration ----");
+        infof("  navFreq   : %u Hz", (unsigned)navFreqHz);
+        infof("  measRate  : %u ms",  (unsigned)measRate);
+        infof("  navRate   : %u cycles/fix", (unsigned)navRate);
+        infof("  protoVer  : %u.%02u", (unsigned)protoVer, (unsigned)protoMin);
+        // NMEA message rate per UART1 via VALGET (rate=0 means the message is off).
+        infof("  GGA(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_GGA_UART1));
+        infof("  RMC(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_RMC_UART1));
+        infof("  VTG(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_VTG_UART1));
+        infof("  GSA(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_GSA_UART1));
+        infof("  GSV(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_GSV_UART1));
+        infof("  GLL(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_GLL_UART1));
+        infof("  GST(UART1): %u", (unsigned)mainGNSS.getVal8(UBLOX_CFG_MSGOUT_NMEA_ID_GST_UART1));
+        info("--------------------------------");
+    }
+
     if (GPS_DEFAULT_CONFIGURATION) {
         //we could configure the gps module here. Not used for dual antenna setups and custom configurations
         /*myGNSS.setNavigationFrequency(10);

--- a/src/hardware/can/can_manager.cpp
+++ b/src/hardware/can/can_manager.cpp
@@ -1,0 +1,84 @@
+#include "can_manager.h"
+
+#if KEYA_MOTOR
+
+#include "config/pinout.h"
+#include "utils/log.h"
+
+namespace hw {
+namespace can {
+
+static bool driverInstalled = false;
+
+bool init() {
+    if (driverInstalled) return true;
+
+    pinMode(CAN_RX_PIN, INPUT);
+    pinMode(CAN_TX_PIN, OUTPUT);
+
+#if KEYA_NO_ACK
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(
+        (gpio_num_t)CAN_TX_PIN, (gpio_num_t)CAN_RX_PIN, TWAI_MODE_NO_ACK);
+    info("CAN: NO_ACK mode (bench/sniffer build)");
+#else
+    twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT(
+        (gpio_num_t)CAN_TX_PIN, (gpio_num_t)CAN_RX_PIN, TWAI_MODE_NORMAL);
+#endif
+    g_config.alerts_enabled = TWAI_ALERT_ABOVE_ERR_WARN
+                            | TWAI_ALERT_BUS_ERROR
+                            | TWAI_ALERT_TX_FAILED
+                            | TWAI_ALERT_RX_QUEUE_FULL
+                            | TWAI_ALERT_BUS_OFF;
+    g_config.rx_queue_len = 32;
+    g_config.tx_queue_len = 16;
+
+    twai_timing_config_t t_config = TWAI_TIMING_CONFIG_250KBITS();
+    twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+    if (twai_driver_install(&g_config, &t_config, &f_config) != ESP_OK) {
+        error("CAN: driver install failed");
+        return false;
+    }
+    if (twai_start() != ESP_OK) {
+        error("CAN: start failed");
+        twai_driver_uninstall();
+        return false;
+    }
+
+    driverInstalled = true;
+    infof("CAN: started at 250kbps (TX=%d RX=%d)", CAN_TX_PIN, CAN_RX_PIN);
+    return true;
+}
+
+bool send(const twai_message_t& msg, TickType_t timeout) {
+    if (!driverInstalled) return false;
+    return twai_transmit(&msg, timeout) == ESP_OK;
+}
+
+bool receive(twai_message_t& msg, TickType_t timeout) {
+    if (!driverInstalled) return false;
+    return twai_receive(&msg, timeout) == ESP_OK;
+}
+
+static void drainAlerts() {
+    uint32_t alerts = 0;
+    if (twai_read_alerts(&alerts, 0) != ESP_OK || alerts == 0) return;
+    if (alerts & TWAI_ALERT_BUS_OFF)        error("CAN: bus-off");
+    if (alerts & TWAI_ALERT_BUS_ERROR)      error("CAN: bus error");
+    if (alerts & TWAI_ALERT_TX_FAILED)      error("CAN: tx failed");
+    if (alerts & TWAI_ALERT_RX_QUEUE_FULL)  warning("CAN: rx queue full");
+    if (alerts & TWAI_ALERT_ABOVE_ERR_WARN) warning("CAN: error counter above warn");
+}
+
+[[noreturn]] void task(void* pvParameters) {
+    (void)pvParameters;
+    while (true) {
+        drainAlerts();
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+}
+
+} // namespace can
+} // namespace hw
+
+#endif // KEYA_MOTOR

--- a/src/hardware/can/can_manager.h
+++ b/src/hardware/can/can_manager.h
@@ -1,0 +1,27 @@
+#ifndef CAN_MANAGER_H
+#define CAN_MANAGER_H
+
+#include "config/defines.h"
+
+#if KEYA_MOTOR
+
+#include <Arduino.h>
+#include "driver/twai.h"
+
+namespace hw {
+namespace can {
+
+bool init();
+
+bool send(const twai_message_t& msg, TickType_t timeout = pdMS_TO_TICKS(20));
+
+bool receive(twai_message_t& msg, TickType_t timeout = pdMS_TO_TICKS(50));
+
+[[noreturn]] void task(void* pvParameters);
+
+} // namespace can
+} // namespace hw
+
+#endif // KEYA_MOTOR
+
+#endif // CAN_MANAGER_H

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -24,85 +24,65 @@
 
 namespace hw{
 
+// Subsystem-presence tracker, populated by init(). Used by the test task
+// (under TEST_MODE) and other code that wants to know whether a peripheral
+// came up so it can adapt its behaviour.
+TestStatus testStatus;
+
+// Helper: in TEST_MODE turn an init failure into a warning + continue.
+// Outside TEST_MODE the original "halt on first failure" semantics hold.
+#if TEST_MODE
+  #define INIT_OR_HALT(call, name)                                          \
+      do {                                                                  \
+          if (!(call)) {                                                    \
+              warningf("TEST_MODE: %s init failed - continuing", #name);    \
+          } else { testStatus.name##_ok = true; }                           \
+      } while (0)
+#else
+  #define INIT_OR_HALT(call, name)                                          \
+      do {                                                                  \
+          if (!(call)) {                                                    \
+              errorf("%s initialization failed", #name);                    \
+              return false;                                                 \
+          }                                                                 \
+          testStatus.name##_ok = true;                                      \
+      } while (0)
+#endif
+
 bool init(){
-    if (!initI2CManager()) {
-        error("FATAL: I2C Manager initialization failed");
-        return false;
-    }
-
-    if (!Settings::init()) {
-        error("Settings initialization failed");
-        return false;
-    }
-
-    if (!Buttons::init()) {
-        error("Buttons initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(initI2CManager(),    i2c);
+    INIT_OR_HALT(Settings::init(),    settings);
+    INIT_OR_HALT(Buttons::init(),     buttons);
 
     // Init BNO first since it uses I2C. In SIMULATOR mode the BNO08x is
     // optional - the sim will register its own heading provider after this
-    // runs. We still try to bring up the chip so its data path is available
-    // for verification, but a missing sensor is non-fatal.
-    if (!BNO08XIMU::init()) {
+    // runs.
 #if SIMULATOR
+    if (!BNO08XIMU::init()) {
         warning("SIMULATOR: BNO08X init failed - continuing, sim provides heading");
+    } else { testStatus.imu_ok = true; }
 #else
-        error("BNO08X IMU initialization failed");
-        return false;
+    INIT_OR_HALT(BNO08XIMU::init(),   imu);
 #endif
-    }
 
 #if KEYA_WAS
-    // KeyaMotor must come up before KeyaWAS so the heartbeat parser has
-    // somewhere to write the cumulative position. Init order:
-    //   1. KeyaMotor (CAN driver + heartbeat parser, registers MotorInterface)
-    //   2. KeyaWAS   (registers WASInterface, reads from KeyaMotor)
-    if (!KeyaMotor::init()) {
-        error("Keya Motor initialization failed");
-        return false;
-    }
-    if (!KeyaWAS::init()) {
-        error("Keya WAS initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(KeyaMotor::init(),   motor);
+    INIT_OR_HALT(KeyaWAS::init(),     was);
 #else
-    if (!ADS1115WAS::init()) {
-        error("ADS1115 WAS initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(ADS1115WAS::init(),  was);
   #if KEYA_MOTOR
-    if (!KeyaMotor::init()) {
-        error("Keya Motor initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(KeyaMotor::init(),   motor);
   #else
-    if (!PWMMotor::init()) {
-        error("PWM Motor initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(PWMMotor::init(),    motor);
   #endif
 #endif
 
 #if SIMULATOR
-    // In sim mode the real GPS UART is skipped entirely - the simulator emits
-    // NMEA directly to UDP. This also means the device works on the bench
-    // with no u-blox attached or no satellite fix.
-    if (!sim::init()) {
-        error("Simulator initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(sim::init(),         gps);
 #else
-    if (!gps_main::init()) {
-        error("Main GPS initialization failed");
-        return false;
-    }
-
+    INIT_OR_HALT(gps_main::init(),    gps);
   #if GPS_HEADING
-    if (!gps_heading::init()) {
-        error("GPS Heading initialization failed");
-        return false;
-    }
+    INIT_OR_HALT(gps_heading::init(), gpsHeading);
   #else
     debug("GPS heading disabled (single-GPS build)");
   #endif

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -14,6 +14,9 @@
 #include "gps/gps_module.h"
 #include "settings/settings_hw.h"
 #include "utils/log.h"
+#if SIMULATOR
+#include "sim/bicycle_sim.h"
+#endif
 
 namespace hw{
 
@@ -33,10 +36,17 @@ bool init(){
         return false;
     }
 
-    // Init BNO first since it uses I2C
+    // Init BNO first since it uses I2C. In SIMULATOR mode the BNO08x is
+    // optional - the sim will register its own heading provider after this
+    // runs. We still try to bring up the chip so its data path is available
+    // for verification, but a missing sensor is non-fatal.
     if (!BNO08XIMU::init()) {
+#if SIMULATOR
+        warning("SIMULATOR: BNO08X init failed - continuing, sim provides heading");
+#else
         error("BNO08X IMU initialization failed");
         return false;
+#endif
     }
 
     if (!ADS1115WAS::init()) {
@@ -56,18 +66,28 @@ bool init(){
     }
 #endif
 
+#if SIMULATOR
+    // In sim mode the real GPS UART is skipped entirely - the simulator emits
+    // NMEA directly to UDP. This also means the device works on the bench
+    // with no u-blox attached or no satellite fix.
+    if (!sim::init()) {
+        error("Simulator initialization failed");
+        return false;
+    }
+#else
     if (!gps_main::init()) {
         error("Main GPS initialization failed");
         return false;
     }
 
-#if GPS_HEADING
+  #if GPS_HEADING
     if (!gps_heading::init()) {
         error("GPS Heading initialization failed");
         return false;
     }
-#else
+  #else
     debug("GPS heading disabled (single-GPS build)");
+  #endif
 #endif
 
     debug("Hardware initialization done!");

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -4,7 +4,11 @@
 #include "i2c_manager.h"
 #include "imu/bno08x_imu.h"
 #include "was/ads1115_was.h"
+#if KEYA_MOTOR
+#include "motor/keya_motor.h"
+#else
 #include "motor/pwm_motor.h"
+#endif
 #include "buttons/buttons_hw.h"
 #include "gps/gps_heading.h"
 #include "gps/gps_module.h"
@@ -40,10 +44,17 @@ bool init(){
         return false;
     }
 
+#if KEYA_MOTOR
+    if (!KeyaMotor::init()) {
+        error("Keya Motor initialization failed");
+        return false;
+    }
+#else
     if (!PWMMotor::init()) {
         error("PWM Motor initialization failed");
         return false;
     }
+#endif
 
     if (!gps_main::init()) {
         error("Main GPS initialization failed");

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -3,7 +3,11 @@
 #include "config/defines.h"
 #include "i2c_manager.h"
 #include "imu/bno08x_imu.h"
+#if KEYA_WAS
+#include "was/keya_was.h"
+#else
 #include "was/ads1115_was.h"
+#endif
 #if KEYA_MOTOR
 #include "motor/keya_motor.h"
 #else
@@ -49,21 +53,35 @@ bool init(){
 #endif
     }
 
-    if (!ADS1115WAS::init()) {
-        error("ADS1115 WAS initialization failed");
-        return false;
-    }
-
-#if KEYA_MOTOR
+#if KEYA_WAS
+    // KeyaMotor must come up before KeyaWAS so the heartbeat parser has
+    // somewhere to write the cumulative position. Init order:
+    //   1. KeyaMotor (CAN driver + heartbeat parser, registers MotorInterface)
+    //   2. KeyaWAS   (registers WASInterface, reads from KeyaMotor)
     if (!KeyaMotor::init()) {
         error("Keya Motor initialization failed");
         return false;
     }
+    if (!KeyaWAS::init()) {
+        error("Keya WAS initialization failed");
+        return false;
+    }
 #else
+    if (!ADS1115WAS::init()) {
+        error("ADS1115 WAS initialization failed");
+        return false;
+    }
+  #if KEYA_MOTOR
+    if (!KeyaMotor::init()) {
+        error("Keya Motor initialization failed");
+        return false;
+    }
+  #else
     if (!PWMMotor::init()) {
         error("PWM Motor initialization failed");
         return false;
     }
+  #endif
 #endif
 
 #if SIMULATOR

--- a/src/hardware/hardware.h
+++ b/src/hardware/hardware.h
@@ -4,6 +4,22 @@
 
 namespace hw{
 
+// Per-subsystem init result. Populated by init(); useful for the test task
+// and any other code wanting to know whether a given peripheral came up
+// (especially when TEST_MODE allows a partial boot).
+struct TestStatus {
+    bool i2c_ok        = false;
+    bool settings_ok   = false;
+    bool buttons_ok    = false;
+    bool imu_ok        = false;
+    bool was_ok        = false;
+    bool motor_ok      = false;
+    bool gps_ok        = false;
+    bool gpsHeading_ok = false;
+};
+
+extern TestStatus testStatus;
+
 bool init();
 }
 

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -1,0 +1,188 @@
+#include "keya_motor.h"
+
+#if KEYA_MOTOR
+
+#include "../../autosteer/motor.h"
+#include "../can/can_manager.h"
+#include "../../utils/log.h"
+
+namespace hw {
+
+// Keya CAN protocol constants (see memory/keya_teensy_reference.md)
+static constexpr uint32_t KEYA_TX_ID        = 0x06000001; // outgoing commands
+static constexpr uint32_t KEYA_HEARTBEAT_ID = 0x07000001; // incoming heartbeat
+
+// Heartbeat staleness watchdog. Default cadence is 20ms, so 200ms is 10
+// missed frames. Anything older than this marks the motor unhealthy.
+static constexpr uint32_t KEYA_STALE_MS = 200;
+
+// Speed mapping: autosteer pwm magnitude is 0..255, sign comes from the
+// `reversed` flag. Keya wants signed int16 speed in [-995..998].
+static constexpr int16_t KEYA_SPEED_MAX = 998;
+static constexpr int16_t KEYA_SPEED_MIN = -995;
+
+bool KeyaMotor::initialized = false;
+uint8_t KeyaMotor::currentPwm = 0;
+
+static volatile bool     healthyFlag    = false;
+static volatile uint32_t lastSeenMs     = 0;
+static volatile uint16_t lastErrorCode  = 0;
+static volatile uint16_t lastCurrentMA  = 0;
+
+static void buildBaseFrame(twai_message_t& msg) {
+    memset(&msg, 0, sizeof(msg));
+    msg.identifier = KEYA_TX_ID;
+    msg.extd = 1;
+    msg.data_length_code = 8;
+}
+
+static void sendEnable() {
+    twai_message_t m;
+    buildBaseFrame(m);
+    m.data[0] = 0x23;
+    m.data[1] = 0x0D;
+    m.data[2] = 0x20;
+    m.data[3] = 0x01;
+    hw::can::send(m);
+}
+
+static void sendDisable() {
+    twai_message_t m;
+    buildBaseFrame(m);
+    m.data[0] = 0x23;
+    m.data[1] = 0x0C;
+    m.data[2] = 0x20;
+    m.data[3] = 0x01;
+    hw::can::send(m);
+}
+
+static void sendSpeed(int16_t signedSpeed) {
+    twai_message_t m;
+    buildBaseFrame(m);
+    m.data[0] = 0x23;
+    m.data[1] = 0x00;
+    m.data[2] = 0x20;
+    m.data[3] = 0x01;
+    m.data[4] = (uint8_t)((signedSpeed >> 8) & 0xFF); // hi
+    m.data[5] = (uint8_t)(signedSpeed & 0xFF);        // lo
+    if (signedSpeed < 0) {
+        m.data[6] = 0xFF;
+        m.data[7] = 0xFF;
+    } else {
+        m.data[6] = 0x00;
+        m.data[7] = 0x00;
+    }
+    hw::can::send(m);
+}
+
+bool KeyaMotor::init() {
+    if (initialized) return true;
+
+    if (!hw::can::init()) {
+        error("KeyaMotor: CAN init failed");
+        return false;
+    }
+
+    // Wait briefly for the bus to settle, then send a disable so the motor
+    // doesn't act on whatever stale command may have been latched.
+    delay(50);
+    sendDisable();
+
+    motor::MotorInterface interface;
+    interface.drive  = drive;
+    interface.stop   = stop;
+    interface.getPwm = getPwm;
+    motor::init(interface);
+
+    initialized = true;
+    info("KeyaMotor initialized");
+    return true;
+}
+
+void KeyaMotor::drive(uint8_t pwm, bool reversed) {
+    if (!initialized) return;
+
+    if (pwm == 0) {
+        sendDisable();
+        currentPwm = 0;
+        return;
+    }
+
+    if (!isHealthy()) {
+        // Keya heartbeat missing or in fault. Don't drive blind - the user-
+        // facing engage gate (autosteer.cpp) refuses engagement on unhealthy,
+        // but a stale heartbeat between checks would still get here. Log
+        // throttled via the `error counter above warn` path in can_manager.
+        sendDisable();
+        currentPwm = 0;
+        return;
+    }
+
+    int16_t signedPwm  = reversed ? -(int16_t)pwm : (int16_t)pwm;
+    int16_t keyaSpeed  = (int16_t)map(signedPwm, -255, 255, KEYA_SPEED_MIN, KEYA_SPEED_MAX);
+
+    sendSpeed(keyaSpeed);
+    sendEnable();
+    currentPwm = pwm;
+}
+
+void KeyaMotor::stop() {
+    if (!initialized) return;
+    sendSpeed(0);
+    sendDisable();
+    currentPwm = 0;
+}
+
+uint8_t KeyaMotor::getPwm() {
+    return currentPwm;
+}
+
+void KeyaMotor::handler() {
+    if (!initialized) return;
+
+    twai_message_t msg;
+    while (hw::can::receive(msg, pdMS_TO_TICKS(50))) {
+        if (msg.identifier != KEYA_HEARTBEAT_ID) continue;
+        if (msg.data_length_code < 8) continue;
+
+        // Heartbeat layout (from keya_teensy_reference.md):
+        //   [0..1] cumulative angle (signed)
+        //   [2..3] motor speed (signed)
+        //   [4..5] motor current (with symbol)
+        //   [6..7] error code
+        uint16_t errCode = ((uint16_t)msg.data[6] << 8) | msg.data[7];
+        // Current scaling matches the Teensy reference: signed byte 4 acts as
+        // sign, byte 5 magnitude * 20 yields milliamps.
+        uint16_t curMA;
+        if (msg.data[4] == 0xFF) {
+            curMA = (256 - msg.data[5]) * 20;
+        } else {
+            curMA = msg.data[5] * 20;
+        }
+
+        lastErrorCode = errCode;
+        lastCurrentMA = curMA;
+        lastSeenMs    = millis();
+        healthyFlag   = (errCode == 0);
+    }
+
+    // Staleness check - mark unhealthy if no heartbeat for KEYA_STALE_MS.
+    if (healthyFlag && (millis() - lastSeenMs) > KEYA_STALE_MS) {
+        healthyFlag = false;
+    }
+}
+
+bool KeyaMotor::isHealthy() {
+    if (!initialized) return false;
+    if (!healthyFlag) return false;
+    if ((millis() - lastSeenMs) > KEYA_STALE_MS) return false;
+    return true;
+}
+
+uint16_t KeyaMotor::getCurrentMA() {
+    return lastCurrentMA;
+}
+
+} // namespace hw
+
+#endif // KEYA_MOTOR

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -21,6 +21,27 @@ static constexpr uint32_t KEYA_STALE_MS = 200;
 static constexpr int16_t KEYA_SPEED_MAX = 998;
 static constexpr int16_t KEYA_SPEED_MIN = -995;
 
+// Heartbeat error-code bit decode (per KY173 datasheet, sec 4.5.2).
+// errCode is built as (Data6 << 8) | Data7.
+// Data6 bits: 6=CAN break, 5=232 break, 4=current sensing, 3=Hall failure,
+//             2=temp protection, 0=working mode failure.
+// Data7 bits: 7=control signal, 6=overcurrent, 4=undervoltage, 3=E2PROM,
+//             2=hardware protection, 1=overvoltage, 0=Disable.
+//
+// Bits we treat as STATE rather than fault:
+//   - Data7 bit0 (0x0001 "Disable"): the motor truthfully reports it is
+//     disabled. We send disable at init and on stop - that's expected.
+//   - Data6 bit6 (0x4000 "CAN break"): means the motor has not seen a CAN
+//     command for ~1s. Cleared by our keep-alive disable frame, so it
+//     should rarely persist.
+// Anything else is a real fault and blocks engagement.
+static constexpr uint16_t KEYA_NONFAULT_MASK = 0x4001;
+static constexpr uint16_t KEYA_FAULT_MASK    = ~KEYA_NONFAULT_MASK;
+
+// Keep-alive cadence. Keya watchdog fires after 1000ms of CAN silence;
+// 200ms gives us a healthy margin.
+static constexpr uint32_t KEYA_KEEPALIVE_MS = 200;
+
 bool KeyaMotor::initialized = false;
 uint8_t KeyaMotor::currentPwm = 0;
 
@@ -143,6 +164,18 @@ void KeyaMotor::handler() {
     static bool everSeen      = false;
     static bool prevHealthy   = false;
     static uint16_t prevError = 0;
+    static uint32_t lastKeepaliveMs = 0;
+
+    // Keep-alive: the motor's own watchdog (datasheet sec 4.5.1) trips after
+    // 1s of CAN silence, raising the "CAN break" bit in the heartbeat error
+    // code. Send a disable frame periodically when nothing else is being
+    // sent so the motor stays in a clean disabled-but-connected state.
+    if (millis() - lastKeepaliveMs > KEYA_KEEPALIVE_MS) {
+        if (currentPwm == 0) {
+            sendDisable();
+        }
+        lastKeepaliveMs = millis();
+    }
 
     twai_message_t msg;
     while (hw::can::receive(msg, pdMS_TO_TICKS(50))) {
@@ -181,7 +214,9 @@ void KeyaMotor::handler() {
         lastErrorCode = errCode;
         lastCurrentMA = curMA;
         lastSeenMs    = millis();
-        healthyFlag   = (errCode == 0);
+        // Mask out non-fault state bits (Disable, CAN break) - those are
+        // expected operating states, not motor faults.
+        healthyFlag   = ((errCode & KEYA_FAULT_MASK) == 0);
     }
 
     // Staleness check - mark unhealthy if no heartbeat for KEYA_STALE_MS.

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -281,14 +281,30 @@ void KeyaMotor::handler() {
         //   [4..5] motor current (with symbol)
         //   [6..7] error code
         uint16_t errCode = ((uint16_t)msg.data[6] << 8) | msg.data[7];
-        // Current scaling matches the Teensy reference: signed byte 4 acts as
-        // sign, byte 5 magnitude * 20 yields milliamps.
-        uint16_t curMA;
-        if (msg.data[4] == 0xFF) {
-            curMA = (256 - msg.data[5]) * 20;
-        } else {
-            curMA = msg.data[5] * 20;
+        // Heartbeat current per manual sec 4.5.2: bytes [4..5] are a signed
+        // 16-bit value, byte 4 high, byte 5 low (big-endian). The MANUAL DOES
+        // NOT DOCUMENT THE UNIT. Earlier code (inherited from the lansalot
+        // Teensy fork) treated byte 4 as a sign byte and byte 5 magnitude * 20
+        // mA, which only matches an unsigned 0..5 A range and misinterprets
+        // anything larger. With the corrected parse below, "currentRaw" is
+        // the magnitude in whatever units the controller emits; map to mA via
+        // KEYA_CURRENT_RAW_PER_MA once empirically determined.
+        int16_t signedCurrent = (int16_t)(((uint16_t)msg.data[4] << 8) | msg.data[5]);
+        uint16_t currentRaw = (uint16_t)((signedCurrent < 0) ? -signedCurrent
+                                                             : signedCurrent);
+        uint16_t curMA = currentRaw * KEYA_CURRENT_RAW_PER_MA;
+
+#if KEYA_LOG_CURRENT_EVERY > 0
+        // Calibration log: print raw bytes + decoded values periodically so
+        // we can verify the unit scaling against actual measured current.
+        static uint16_t logCurrentCounter = 0;
+        if (++logCurrentCounter >= KEYA_LOG_CURRENT_EVERY) {
+            logCurrentCounter = 0;
+            infof("Keya cur: bytes[4..5]=%02X %02X signed=%d raw=%u curMA=%u",
+                  msg.data[4], msg.data[5], (int)signedCurrent,
+                  (unsigned)currentRaw, (unsigned)curMA);
         }
+#endif
 
         // Cumulative angle (Data0 high, Data1 low; 1 LSB = 1 deg, wraps at
         // 0xFFFF per manual sec 4.5.2). On the first frame, snapshot the

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -50,6 +50,7 @@ static volatile bool     healthyFlag    = false;
 static volatile uint32_t lastSeenMs     = 0;
 static volatile uint16_t lastErrorCode  = 0;
 static volatile uint16_t lastCurrentMA  = 0;
+static volatile uint16_t peakCurrentMA  = 0;
 
 // Cumulative encoder position. The Keya heartbeat reports a uint16 angle
 // counter that wraps at 0xFFFF (one count per degree, per manual sec 4.5.2).
@@ -304,6 +305,7 @@ void KeyaMotor::handler() {
 
         lastErrorCode = errCode;
         lastCurrentMA = curMA;
+        if (curMA > peakCurrentMA) peakCurrentMA = curMA;
         lastSeenMs    = millis();
         // Mask out non-fault state bits (Disable, CAN break) - those are
         // expected operating states, not motor faults.
@@ -336,6 +338,14 @@ bool KeyaMotor::isHealthy() {
 
 uint16_t KeyaMotor::getCurrentMA() {
     return lastCurrentMA;
+}
+
+uint16_t KeyaMotor::getPeakCurrentMA() {
+    return peakCurrentMA;
+}
+
+void KeyaMotor::resetPeakCurrent() {
+    peakCurrentMA = 0;
 }
 
 int32_t KeyaMotor::getCumulativeDegrees() {

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -9,8 +9,9 @@
 namespace hw {
 
 // Keya CAN protocol constants (see memory/keya_teensy_reference.md)
-static constexpr uint32_t KEYA_TX_ID        = 0x06000001; // outgoing commands
-static constexpr uint32_t KEYA_HEARTBEAT_ID = 0x07000001; // incoming heartbeat
+static constexpr uint32_t KEYA_TX_ID         = 0x06000001; // outgoing commands
+static constexpr uint32_t KEYA_HEARTBEAT_ID  = 0x07000001; // incoming heartbeat
+static constexpr uint32_t KEYA_SDO_RESP_ID   = 0x05800001; // SDO-server response
 
 // Heartbeat staleness watchdog. Default cadence is 20ms, so 200ms is 10
 // missed frames. Anything older than this marks the motor unhealthy.
@@ -193,6 +194,66 @@ void KeyaMotor::handler() {
 
     twai_message_t msg;
     while (hw::can::receive(msg, pdMS_TO_TICKS(50))) {
+#if KEYA_SNIFFER
+        // Sniffer: log "interesting" non-routine frames so the user can
+        // reverse-engineer proprietary commands by running another master
+        // (Keya ServoCAN tool) on the same bus. Filter out:
+        //   - Heartbeats (own steady-state, parsed below).
+        //   - SDO write-ACKs to OUR own commands (scs=0x60 + idx in
+        //     {0x2000:00 = speed-ack, 0x200C:00 = disable-ack,
+        //                                 0x200D:00 = enable-ack}).
+        // What's left: any frame from the tool, plus any motor response
+        // we did not initiate.
+        bool isHeartbeat = (msg.identifier == KEYA_HEARTBEAT_ID);
+        bool isOurAck = (msg.identifier == KEYA_SDO_RESP_ID
+                         && msg.data_length_code == 8
+                         && msg.data[0] == 0x60
+                         && msg.data[2] == 0x20
+                         && msg.data[3] == 0x00
+                         && (msg.data[1] == 0x00 || msg.data[1] == 0x0C
+                                                  || msg.data[1] == 0x0D));
+        if (!isHeartbeat && !isOurAck) {
+            debugf("CAN rx id=0x%08X dlc=%u %02X %02X %02X %02X %02X %02X %02X %02X",
+                   msg.identifier, (unsigned)msg.data_length_code,
+                   msg.data[0], msg.data[1], msg.data[2], msg.data[3],
+                   msg.data[4], msg.data[5], msg.data[6], msg.data[7]);
+        }
+#endif
+
+        // SDO responses (read/write replies) arrive on a different COB-ID
+        // than heartbeats. Decode and log them on the debug stream so any
+        // SDO-read utility yields visible data.
+        if (msg.identifier == KEYA_SDO_RESP_ID && msg.data_length_code >= 8) {
+            uint8_t  scs = msg.data[0];
+            uint16_t idx = (uint16_t)msg.data[1] | ((uint16_t)msg.data[2] << 8);
+            uint8_t  sub = msg.data[3];
+            uint32_t data = (uint32_t)msg.data[4]
+                          | ((uint32_t)msg.data[5] << 8)
+                          | ((uint32_t)msg.data[6] << 16)
+                          | ((uint32_t)msg.data[7] << 24);
+            if (scs == 0x80) {
+                // Abort transfer - object/subindex doesn't exist or is denied.
+                debugf("Keya SDO abort idx=0x%04X sub=0x%02X code=0x%08X",
+                       idx, sub, data);
+            } else if ((scs & 0xE0) == 0x40) {
+                // Upload response (0x42=4-byte, 0x43..0x4F=expedited variants).
+                infof("Keya SDO read idx=0x%04X sub=0x%02X scs=0x%02X data=0x%08X (%d)",
+                      idx, sub, scs, data, (int)data);
+            } else {
+                // Quiet about routine write-ACKs (scs=0x60) for our own
+                // commands - those are the speed/disable/enable ACKs at
+                // 0x2000/0x200C/0x200D and just clutter the log.
+                bool routineAck = (scs == 0x60 && sub == 0x00
+                                   && (idx == 0x2000 || idx == 0x200C
+                                                     || idx == 0x200D));
+                if (!routineAck) {
+                    debugf("Keya SDO frame idx=0x%04X sub=0x%02X scs=0x%02X data=0x%08X",
+                           idx, sub, scs, data);
+                }
+            }
+            continue;
+        }
+
         if (msg.identifier != KEYA_HEARTBEAT_ID) continue;
         if (msg.data_length_code < 8) continue;
 
@@ -283,6 +344,54 @@ int32_t KeyaMotor::getCumulativeDegrees() {
 
 bool KeyaMotor::hasPositionRef() {
     return posRefValid;
+}
+
+bool KeyaMotor::sdoRead(uint16_t index, uint8_t subindex) {
+    twai_message_t m;
+    buildBaseFrame(m);
+    m.data[0] = 0x40;                       // SDO initiate upload (read)
+    m.data[1] = (uint8_t)(index & 0xFF);    // index low (CANopen LE)
+    m.data[2] = (uint8_t)(index >> 8);      // index high
+    m.data[3] = subindex;
+    // Bytes 4..7 are reserved/zero on an upload request.
+    return hw::can::send(m);
+}
+
+void KeyaMotor::probeMaxCurrent() {
+    info("Keya: probing OD for max-current parameter...");
+
+    // Confidence check first: the manual documents 0x2100:01 as "motor current
+    // query". If our SDO mechanism is correct we should see a response with
+    // the live current value. If this one is silent too, the issue is
+    // somewhere in our CAN plumbing rather than the OD addressing.
+    sdoRead(0x2100, 0x01);                  // KNOWN: live motor current
+    delay(40);
+    sdoRead(0x210F, 0x01);                  // KNOWN: motor temperature
+    delay(40);
+    sdoRead(0x210D, 0x02);                  // KNOWN: power supply voltage
+    delay(40);
+
+    // CANopen DSP402 motor-profile candidates.
+    sdoRead(0x6073, 0x00);                  // Max Current
+    delay(40);
+    sdoRead(0x6075, 0x00);                  // Motor Rated Current
+    delay(40);
+    sdoRead(0x6076, 0x00);                  // Motor Rated Torque
+    delay(40);
+
+    // Keya-specific guesses for configuration parameter 3 (Max current).
+    sdoRead(0x2003, 0x00);
+    delay(40);
+    sdoRead(0x2003, 0x01);
+    delay(40);
+    sdoRead(0x2103, 0x03);
+    delay(40);
+    sdoRead(0x210C, 0x03);
+    delay(40);
+    sdoRead(0x2200, 0x03);
+    delay(40);
+    sdoRead(0x2F03, 0x00);
+    delay(40);
 }
 
 } // namespace hw

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -70,6 +70,9 @@ static void buildBaseFrame(twai_message_t& msg) {
 }
 
 static void sendEnable() {
+#if KEYA_LISTEN_ONLY
+    return;
+#else
     twai_message_t m;
     buildBaseFrame(m);
     m.data[0] = 0x23;
@@ -77,9 +80,13 @@ static void sendEnable() {
     m.data[2] = 0x20;
     m.data[3] = 0x01;
     hw::can::send(m);
+#endif
 }
 
 static void sendDisable() {
+#if KEYA_LISTEN_ONLY
+    return;
+#else
     twai_message_t m;
     buildBaseFrame(m);
     m.data[0] = 0x23;
@@ -87,9 +94,14 @@ static void sendDisable() {
     m.data[2] = 0x20;
     m.data[3] = 0x01;
     hw::can::send(m);
+#endif
 }
 
 static void sendSpeed(int16_t signedSpeed) {
+#if KEYA_LISTEN_ONLY
+    (void)signedSpeed;
+    return;
+#else
     twai_message_t m;
     buildBaseFrame(m);
     m.data[0] = 0x23;
@@ -106,6 +118,7 @@ static void sendSpeed(int16_t signedSpeed) {
         m.data[7] = 0x00;
     }
     hw::can::send(m);
+#endif
 }
 
 bool KeyaMotor::init() {
@@ -128,7 +141,11 @@ bool KeyaMotor::init() {
     motor::init(interface);
 
     initialized = true;
+#if KEYA_LISTEN_ONLY
+    info("KeyaMotor initialized (LISTEN-ONLY: no CAN tx will be issued)");
+#else
     info("KeyaMotor initialized");
+#endif
     return true;
 }
 

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -50,6 +50,16 @@ static volatile uint32_t lastSeenMs     = 0;
 static volatile uint16_t lastErrorCode  = 0;
 static volatile uint16_t lastCurrentMA  = 0;
 
+// Cumulative encoder position. The Keya heartbeat reports a uint16 angle
+// counter that wraps at 0xFFFF (one count per degree, per manual sec 4.5.2).
+// On the first heartbeat we snapshot the raw value; thereafter we compute a
+// signed 16-bit delta from the previous reading - that delta wraps correctly
+// for small per-tick motions (typically <<1 deg per 20ms heartbeat) - and
+// accumulate into a 32-bit signed running total in degrees from boot zero.
+static volatile bool     posRefValid    = false;
+static volatile uint16_t lastRawAngle   = 0;
+static volatile int32_t  cumulativeDeg  = 0;
+
 static void buildBaseFrame(twai_message_t& msg) {
     memset(&msg, 0, sizeof(msg));
     msg.identifier = KEYA_TX_ID;
@@ -123,18 +133,22 @@ bool KeyaMotor::init() {
 void KeyaMotor::drive(uint8_t pwm, bool reversed) {
     if (!initialized) return;
 
-    if (pwm == 0) {
+    if (!isHealthy()) {
+        // Keya heartbeat missing or in fault. Don't drive blind - the user-
+        // facing engage gate (autosteer.cpp) refuses engagement on unhealthy,
+        // but a stale heartbeat between checks would still get here.
         sendDisable();
         currentPwm = 0;
         return;
     }
 
-    if (!isHealthy()) {
-        // Keya heartbeat missing or in fault. Don't drive blind - the user-
-        // facing engage gate (autosteer.cpp) refuses engagement on unhealthy,
-        // but a stale heartbeat between checks would still get here. Log
-        // throttled via the `error counter above warn` path in can_manager.
-        sendDisable();
+    if (pwm == 0) {
+        // Zero error from PID. Hold position rather than coast: keep the
+        // motor enabled with speed=0 so its closed-loop speed control
+        // actively resists external rotation. Disabling here would let
+        // the wheel drift off the setpoint until the next non-zero error.
+        sendSpeed(0);
+        sendEnable();
         currentPwm = 0;
         return;
     }
@@ -197,6 +211,22 @@ void KeyaMotor::handler() {
             curMA = msg.data[5] * 20;
         }
 
+        // Cumulative angle (Data0 high, Data1 low; 1 LSB = 1 deg, wraps at
+        // 0xFFFF per manual sec 4.5.2). On the first frame, snapshot the
+        // raw value as the zero reference; afterwards, compute the signed
+        // 16-bit delta and accumulate. uint16 subtraction wraps correctly
+        // for small per-tick motions.
+        uint16_t rawAngle = ((uint16_t)msg.data[0] << 8) | msg.data[1];
+        if (!posRefValid) {
+            lastRawAngle = rawAngle;
+            cumulativeDeg = 0;
+            posRefValid = true;
+        } else {
+            int16_t delta = (int16_t)(rawAngle - lastRawAngle);
+            cumulativeDeg += delta;
+            lastRawAngle = rawAngle;
+        }
+
         if (!everSeen) {
             infof("Keya: first heartbeat received (current=%umA, errCode=0x%04X)",
                   curMA, errCode);
@@ -245,6 +275,14 @@ bool KeyaMotor::isHealthy() {
 
 uint16_t KeyaMotor::getCurrentMA() {
     return lastCurrentMA;
+}
+
+int32_t KeyaMotor::getCumulativeDegrees() {
+    return cumulativeDeg;
+}
+
+bool KeyaMotor::hasPositionRef() {
+    return posRefValid;
 }
 
 } // namespace hw

--- a/src/hardware/motor/keya_motor.cpp
+++ b/src/hardware/motor/keya_motor.cpp
@@ -140,6 +140,10 @@ uint8_t KeyaMotor::getPwm() {
 void KeyaMotor::handler() {
     if (!initialized) return;
 
+    static bool everSeen      = false;
+    static bool prevHealthy   = false;
+    static uint16_t prevError = 0;
+
     twai_message_t msg;
     while (hw::can::receive(msg, pdMS_TO_TICKS(50))) {
         if (msg.identifier != KEYA_HEARTBEAT_ID) continue;
@@ -160,6 +164,20 @@ void KeyaMotor::handler() {
             curMA = msg.data[5] * 20;
         }
 
+        if (!everSeen) {
+            infof("Keya: first heartbeat received (current=%umA, errCode=0x%04X)",
+                  curMA, errCode);
+            everSeen = true;
+        }
+        if (errCode != prevError) {
+            if (errCode == 0) {
+                info("Keya: error cleared");
+            } else {
+                errorf("Keya: error code 0x%04X", errCode);
+            }
+            prevError = errCode;
+        }
+
         lastErrorCode = errCode;
         lastCurrentMA = curMA;
         lastSeenMs    = millis();
@@ -169,6 +187,17 @@ void KeyaMotor::handler() {
     // Staleness check - mark unhealthy if no heartbeat for KEYA_STALE_MS.
     if (healthyFlag && (millis() - lastSeenMs) > KEYA_STALE_MS) {
         healthyFlag = false;
+    }
+
+    // Transition logging so the operator sees health flips on the debug stream.
+    bool curHealthy = healthyFlag;
+    if (curHealthy != prevHealthy) {
+        if (curHealthy) {
+            info("Keya: healthy");
+        } else {
+            error("Keya: unhealthy (heartbeat stale or fault)");
+        }
+        prevHealthy = curHealthy;
     }
 }
 

--- a/src/hardware/motor/keya_motor.h
+++ b/src/hardware/motor/keya_motor.h
@@ -28,6 +28,16 @@ public:
     // reference: bytes 4-5 of heartbeat). Returns 0 if no heartbeat yet.
     static uint16_t getCurrentMA();
 
+    // Cumulative encoder position in signed degrees from boot position. The
+    // first heartbeat after boot snapshots the raw encoder value as the zero
+    // reference; subsequent heartbeats unwrap deltas and accumulate. Returns
+    // 0 until the first heartbeat. Used by the KeyaWAS virtual WAS shim.
+    static int32_t getCumulativeDegrees();
+
+    // True once at least one heartbeat has been processed - the cumulative
+    // position is meaningful only after this is true.
+    static bool hasPositionRef();
+
 private:
     static bool initialized;
     static uint8_t currentPwm;

--- a/src/hardware/motor/keya_motor.h
+++ b/src/hardware/motor/keya_motor.h
@@ -28,6 +28,11 @@ public:
     // reference: bytes 4-5 of heartbeat). Returns 0 if no heartbeat yet.
     static uint16_t getCurrentMA();
 
+    // Peak current observed since the last call to resetPeakCurrent().
+    // Updated continuously from heartbeat parsing.
+    static uint16_t getPeakCurrentMA();
+    static void     resetPeakCurrent();
+
     // Cumulative encoder position in signed degrees from boot position. The
     // first heartbeat after boot snapshots the raw encoder value as the zero
     // reference; subsequent heartbeats unwrap deltas and accumulate. Returns

--- a/src/hardware/motor/keya_motor.h
+++ b/src/hardware/motor/keya_motor.h
@@ -1,0 +1,40 @@
+#ifndef KEYA_MOTOR_H
+#define KEYA_MOTOR_H
+
+#include "config/defines.h"
+
+#if KEYA_MOTOR
+
+#include <Arduino.h>
+
+namespace hw {
+
+class KeyaMotor {
+public:
+    static bool init();
+    static void drive(uint8_t pwm, bool reversed);
+    static void stop();
+    static uint8_t getPwm();
+
+    // Heartbeat handler. Drains the CAN driver's RX path and updates the
+    // staleness/health flags. Call from a dedicated FreeRTOS task.
+    static void handler();
+
+    // True when a Keya heartbeat has been seen within KEYA_STALE_MS and the
+    // error-code field of that heartbeat was zero.
+    static bool isHealthy();
+
+    // Last reported motor current in milliamps (raw scaling per the Teensy
+    // reference: bytes 4-5 of heartbeat). Returns 0 if no heartbeat yet.
+    static uint16_t getCurrentMA();
+
+private:
+    static bool initialized;
+    static uint8_t currentPwm;
+};
+
+} // namespace hw
+
+#endif // KEYA_MOTOR
+
+#endif // KEYA_MOTOR_H

--- a/src/hardware/motor/keya_motor.h
+++ b/src/hardware/motor/keya_motor.h
@@ -38,6 +38,18 @@ public:
     // position is meaningful only after this is true.
     static bool hasPositionRef();
 
+    // Send a CANopen-style SDO upload (read) request to the motor controller.
+    // The response arrives on the standard SDO-server COB-ID and is decoded
+    // + logged in handler(). Non-destructive: only the controller's response
+    // is observed.
+    static bool sdoRead(uint16_t index, uint8_t subindex);
+
+    // One-shot probe that fires read requests at several plausible OD
+    // locations for parameter 0003 (Max current) since the manual does not
+    // explicitly document the SDO addressing for configuration parameters.
+    // Whatever the motor returns is logged on the debug stream.
+    static void probeMaxCurrent();
+
 private:
     static bool initialized;
     static uint8_t currentPwm;

--- a/src/hardware/was/keya_was.cpp
+++ b/src/hardware/was/keya_was.cpp
@@ -8,15 +8,27 @@
 
 namespace hw {
 
-static constexpr int32_t KEYA_WAS_HALF_RANGE = KEYA_WAS_RANGE_DEG / 2;
-static constexpr int32_t KEYA_WAS_RAW_LIMIT  = KEYA_WAS_HALF_RANGE * KEYA_WAS_COUNTS_PER_DEG;
+// Encoder full lock = +-half_range degrees on the steering shaft.
+static constexpr int32_t ENC_HALF_RANGE_DEG = KEYA_WAS_RANGE_DEG / 2;
+
+// Numerator/denominator of the reduction from encoder degree to output
+// degree. With ENC_HALF_RANGE_DEG=450 and KEYA_WAS_OUT_HALF_DEG=45 the
+// reduction is 10:1, so multiplying encoder_deg * COUNTS_PER_OUT_DEG /
+// ENC_TO_OUT yields the raw count.
+//
+//   raw = encoder_deg * KEYA_WAS_COUNTS_PER_OUT_DEG / (ENC_HALF / OUT_HALF)
+//       = encoder_deg * KEYA_WAS_COUNTS_PER_OUT_DEG * KEYA_WAS_OUT_HALF_DEG
+//                                                  / ENC_HALF_RANGE_DEG
+static constexpr int32_t RAW_LIMIT =
+    (int32_t)KEYA_WAS_OUT_HALF_DEG * (int32_t)KEYA_WAS_COUNTS_PER_OUT_DEG;
 
 bool KeyaWAS::init() {
     was::WASInterface ifc;
     ifc.readRaw = readRaw;
     was::init(ifc);
-    infof("KeyaWAS initialized (range +-%ld deg, %d count/deg)",
-          (long)KEYA_WAS_HALF_RANGE, KEYA_WAS_COUNTS_PER_DEG);
+    infof("KeyaWAS initialized (encoder +-%ld deg -> WAS +-%d deg, %d counts/out-deg)",
+          (long)ENC_HALF_RANGE_DEG, KEYA_WAS_OUT_HALF_DEG,
+          KEYA_WAS_COUNTS_PER_OUT_DEG);
     return true;
 }
 
@@ -28,12 +40,14 @@ int16_t KeyaWAS::readRaw() {
     }
 
     int32_t deg = KeyaMotor::getCumulativeDegrees();
-    int32_t counts = deg * KEYA_WAS_COUNTS_PER_DEG;
+    // Map encoder degrees -> raw counts at the output scale.
+    int32_t counts = (deg * KEYA_WAS_COUNTS_PER_OUT_DEG * KEYA_WAS_OUT_HALF_DEG)
+                   / ENC_HALF_RANGE_DEG;
 
-    // Clamp to half-range so downstream int16 math stays safe even if a
-    // confused encoder produces a runaway cumulative value.
-    if (counts >  KEYA_WAS_RAW_LIMIT) counts =  KEYA_WAS_RAW_LIMIT;
-    if (counts < -KEYA_WAS_RAW_LIMIT) counts = -KEYA_WAS_RAW_LIMIT;
+    // Clamp to peak output so int16 math stays safe even if a confused
+    // encoder produces a runaway cumulative value.
+    if (counts >  RAW_LIMIT) counts =  RAW_LIMIT;
+    if (counts < -RAW_LIMIT) counts = -RAW_LIMIT;
 
     return (int16_t)counts;
 }

--- a/src/hardware/was/keya_was.cpp
+++ b/src/hardware/was/keya_was.cpp
@@ -1,0 +1,43 @@
+#include "keya_was.h"
+
+#if KEYA_WAS
+
+#include "../motor/keya_motor.h"
+#include "../../autosteer/was.h"
+#include "../../utils/log.h"
+
+namespace hw {
+
+static constexpr int32_t KEYA_WAS_HALF_RANGE = KEYA_WAS_RANGE_DEG / 2;
+static constexpr int32_t KEYA_WAS_RAW_LIMIT  = KEYA_WAS_HALF_RANGE * KEYA_WAS_COUNTS_PER_DEG;
+
+bool KeyaWAS::init() {
+    was::WASInterface ifc;
+    ifc.readRaw = readRaw;
+    was::init(ifc);
+    infof("KeyaWAS initialized (range +-%ld deg, %d count/deg)",
+          (long)KEYA_WAS_HALF_RANGE, KEYA_WAS_COUNTS_PER_DEG);
+    return true;
+}
+
+int16_t KeyaWAS::readRaw() {
+    if (!KeyaMotor::hasPositionRef()) {
+        // No Keya heartbeat seen yet - report center so autosteer behaves
+        // sanely until the first frame arrives.
+        return 0;
+    }
+
+    int32_t deg = KeyaMotor::getCumulativeDegrees();
+    int32_t counts = deg * KEYA_WAS_COUNTS_PER_DEG;
+
+    // Clamp to half-range so downstream int16 math stays safe even if a
+    // confused encoder produces a runaway cumulative value.
+    if (counts >  KEYA_WAS_RAW_LIMIT) counts =  KEYA_WAS_RAW_LIMIT;
+    if (counts < -KEYA_WAS_RAW_LIMIT) counts = -KEYA_WAS_RAW_LIMIT;
+
+    return (int16_t)counts;
+}
+
+} // namespace hw
+
+#endif // KEYA_WAS

--- a/src/hardware/was/keya_was.h
+++ b/src/hardware/was/keya_was.h
@@ -1,0 +1,30 @@
+#ifndef KEYA_WAS_H
+#define KEYA_WAS_H
+
+#include "config/defines.h"
+
+#if KEYA_WAS
+
+#if !KEYA_MOTOR
+#error "KEYA_WAS=1 requires KEYA_MOTOR=1 (the WAS reading comes from the Keya heartbeat)"
+#endif
+
+#include <Arduino.h>
+
+namespace hw {
+
+// Virtual WAS implementation that returns int16 counts derived from the
+// Keya motor's cumulative encoder position. Used when the steering shaft
+// has no dedicated potentiometer/sensor but a Keya motor is mechanically
+// coupled to the column.
+class KeyaWAS {
+public:
+    static bool init();
+    static int16_t readRaw();
+};
+
+} // namespace hw
+
+#endif // KEYA_WAS
+
+#endif // KEYA_WAS_H

--- a/src/network/safe_mode.cpp
+++ b/src/network/safe_mode.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <AsyncUDP.h>
+#include <Preferences.h>
 #include <esp_system.h>
 #include <string.h>
 
@@ -15,6 +16,20 @@ static constexpr uint16_t HALT_UDP_PORT       = 7779;
 static constexpr uint32_t HALT_WINDOW_MS      = 1500;
 static constexpr const char* HALT_MAGIC       = "HALT-AIO-AG";
 static constexpr size_t      HALT_MAGIC_LEN   = 11;
+
+// NVS-backed crash history. Lets the firmware survive a reboot while
+// keeping a running tally of *what* knocked it over - useful for
+// after-the-fact diagnosis when the user only sees the recovered
+// device. Counters bumped per-boot when the new reset reason is a
+// crash flavor; lastReason / lastUptimeMs replaced on every crash.
+static constexpr const char* NVS_NS         = "aioag_crash";
+static constexpr const char* NVS_PANIC      = "panic";
+static constexpr const char* NVS_TASK_WDT   = "tw";
+static constexpr const char* NVS_INT_WDT    = "iw";
+static constexpr const char* NVS_BROWNOUT   = "bo";
+static constexpr const char* NVS_OTHER_WDT  = "wd";
+static constexpr const char* NVS_LAST       = "last";
+static constexpr const char* NVS_BOOTS      = "boots";
 
 static bool g_active = false;
 
@@ -34,26 +49,72 @@ static const char* resetReasonStr(esp_reset_reason_t r) {
     }
 }
 
-static bool isCrashReason(esp_reset_reason_t r) {
-    return r == ESP_RST_PANIC
-        || r == ESP_RST_INT_WDT
-        || r == ESP_RST_TASK_WDT
-        || r == ESP_RST_WDT
-        || r == ESP_RST_BROWNOUT;
+// Map a reset reason to the NVS counter key for that flavor of crash,
+// or nullptr if the reason isn't a crash we track.
+static const char* crashCounterKey(esp_reset_reason_t r) {
+    switch (r) {
+        case ESP_RST_PANIC:    return NVS_PANIC;
+        case ESP_RST_TASK_WDT: return NVS_TASK_WDT;
+        case ESP_RST_INT_WDT:  return NVS_INT_WDT;
+        case ESP_RST_BROWNOUT: return NVS_BROWNOUT;
+        case ESP_RST_WDT:      return NVS_OTHER_WDT;
+        default:               return nullptr;
+    }
+}
+
+static void recordBootInNvs(esp_reset_reason_t reason) {
+    Preferences p;
+    if (!p.begin(NVS_NS, false)) {
+        warning("safe_mode: NVS open failed - crash trace disabled");
+        return;
+    }
+    p.putUInt(NVS_BOOTS, p.getUInt(NVS_BOOTS, 0) + 1);
+    const char* key = crashCounterKey(reason);
+    if (key) {
+        p.putUInt(key, p.getUInt(key, 0) + 1);
+        p.putUChar(NVS_LAST, (uint8_t)reason);
+    }
+    p.end();
+}
+
+static void logCrashHistory() {
+    Preferences p;
+    if (!p.begin(NVS_NS, true)) return;
+    uint32_t boots    = p.getUInt(NVS_BOOTS, 0);
+    uint32_t panic    = p.getUInt(NVS_PANIC, 0);
+    uint32_t taskWdt  = p.getUInt(NVS_TASK_WDT, 0);
+    uint32_t intWdt   = p.getUInt(NVS_INT_WDT, 0);
+    uint32_t brownout = p.getUInt(NVS_BROWNOUT, 0);
+    uint32_t otherWdt = p.getUInt(NVS_OTHER_WDT, 0);
+    uint8_t  lastR    = p.getUChar(NVS_LAST, (uint8_t)ESP_RST_UNKNOWN);
+    p.end();
+
+    uint32_t totalCrashes = panic + taskWdt + intWdt + brownout + otherWdt;
+    if (totalCrashes == 0) {
+        infof("Crash history: clean (%u boots logged)", (unsigned)boots);
+        return;
+    }
+    infof("Crash history: %u crashes / %u boots - panic=%u taskWdt=%u intWdt=%u brownout=%u otherWdt=%u, last=%s",
+          (unsigned)totalCrashes, (unsigned)boots,
+          (unsigned)panic, (unsigned)taskWdt, (unsigned)intWdt,
+          (unsigned)brownout, (unsigned)otherWdt,
+          resetReasonStr((esp_reset_reason_t)lastR));
 }
 
 void checkAtBoot() {
+    // Log the reset reason every boot - useful diagnostic on its own,
+    // even though we no longer act on it (a single transient brownout
+    // or panic shouldn't quarantine the device).
     esp_reset_reason_t reason = esp_reset_reason();
     infof("Reset reason: %s", resetReasonStr(reason));
 
-    if (isCrashReason(reason)) {
-        warning("Previous boot ended in a crash - engaging SAFE MODE");
-        g_active = true;
-    }
+    // Persist the boot to NVS and replay accumulated history. The
+    // counters are append-only across reboots and only ever zeroed if
+    // the user explicitly wipes NVS, so they're a long-running picture
+    // of what's been knocking the device over.
+    recordBootInNvs(reason);
+    logCrashHistory();
 
-    // Always offer the manual escape hatch, even on a clean boot. Lets
-    // the user pre-empt task creation if they suspect the next normal
-    // boot will wedge in a way the reset-reason check can't catch.
     infof("Send '%s' UDP to port %u within %lu ms to force safe mode",
           HALT_MAGIC, (unsigned)HALT_UDP_PORT, (unsigned long)HALT_WINDOW_MS);
 
@@ -76,12 +137,9 @@ void checkAtBoot() {
     }
     haltUdp.close();
 
-    if (halted && !g_active) {
+    if (halted) {
         warning("HALT packet received - engaging SAFE MODE");
         g_active = true;
-    }
-
-    if (g_active) {
         info("=========================================");
         info("  SAFE MODE: tasks suspended, OTA active ");
         info("  Flash a fix via OTA, then reset.       ");

--- a/src/network/safe_mode.cpp
+++ b/src/network/safe_mode.cpp
@@ -1,0 +1,105 @@
+#include "safe_mode.h"
+
+#include <Arduino.h>
+#include <AsyncUDP.h>
+#include <esp_system.h>
+#include <string.h>
+
+#include "utils/log.h"
+
+namespace safe_mode {
+
+// 7777 is the UDP log broadcast port - already bound by UDPStream so we
+// can't listen on it. Use a dedicated port for the HALT escape hatch.
+static constexpr uint16_t HALT_UDP_PORT       = 7779;
+static constexpr uint32_t HALT_WINDOW_MS      = 1500;
+static constexpr const char* HALT_MAGIC       = "HALT-AIO-AG";
+static constexpr size_t      HALT_MAGIC_LEN   = 11;
+
+static bool g_active = false;
+
+static const char* resetReasonStr(esp_reset_reason_t r) {
+    switch (r) {
+        case ESP_RST_POWERON:   return "POWERON";
+        case ESP_RST_EXT:       return "EXT";
+        case ESP_RST_SW:        return "SW";
+        case ESP_RST_PANIC:     return "PANIC";
+        case ESP_RST_INT_WDT:   return "INT_WDT";
+        case ESP_RST_TASK_WDT:  return "TASK_WDT";
+        case ESP_RST_WDT:       return "WDT";
+        case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
+        case ESP_RST_BROWNOUT:  return "BROWNOUT";
+        case ESP_RST_SDIO:      return "SDIO";
+        default:                return "UNKNOWN";
+    }
+}
+
+static bool isCrashReason(esp_reset_reason_t r) {
+    return r == ESP_RST_PANIC
+        || r == ESP_RST_INT_WDT
+        || r == ESP_RST_TASK_WDT
+        || r == ESP_RST_WDT
+        || r == ESP_RST_BROWNOUT;
+}
+
+void checkAtBoot() {
+    esp_reset_reason_t reason = esp_reset_reason();
+    infof("Reset reason: %s", resetReasonStr(reason));
+
+    if (isCrashReason(reason)) {
+        warning("Previous boot ended in a crash - engaging SAFE MODE");
+        g_active = true;
+    }
+
+    // Always offer the manual escape hatch, even on a clean boot. Lets
+    // the user pre-empt task creation if they suspect the next normal
+    // boot will wedge in a way the reset-reason check can't catch.
+    infof("Send '%s' UDP to port %u within %lu ms to force safe mode",
+          HALT_MAGIC, (unsigned)HALT_UDP_PORT, (unsigned long)HALT_WINDOW_MS);
+
+    AsyncUDP haltUdp;
+    volatile bool halted = false;
+    if (haltUdp.listen(HALT_UDP_PORT)) {
+        haltUdp.onPacket([&halted](AsyncUDPPacket pkt) {
+            if (pkt.length() >= HALT_MAGIC_LEN
+                && memcmp(pkt.data(), HALT_MAGIC, HALT_MAGIC_LEN) == 0) {
+                halted = true;
+            }
+        });
+    } else {
+        warning("safe_mode: failed to bind HALT listener");
+    }
+
+    uint32_t deadline = millis() + HALT_WINDOW_MS;
+    while ((int32_t)(deadline - millis()) > 0 && !halted) {
+        delay(20);
+    }
+    haltUdp.close();
+
+    if (halted && !g_active) {
+        warning("HALT packet received - engaging SAFE MODE");
+        g_active = true;
+    }
+
+    if (g_active) {
+        info("=========================================");
+        info("  SAFE MODE: tasks suspended, OTA active ");
+        info("  Flash a fix via OTA, then reset.       ");
+        info("=========================================");
+    }
+}
+
+bool active() {
+    return g_active;
+}
+
+void tickHeartbeat() {
+    static uint32_t last = 0;
+    uint32_t now = millis();
+    if (now - last >= 5000) {
+        last = now;
+        info("SAFE MODE: alive, awaiting OTA");
+    }
+}
+
+} // namespace safe_mode

--- a/src/network/safe_mode.h
+++ b/src/network/safe_mode.h
@@ -1,0 +1,35 @@
+#ifndef SAFE_MODE_H
+#define SAFE_MODE_H
+
+namespace safe_mode {
+
+// Run the safe-mode probe. Call once during setup(), after Ethernet + UDP
+// logging + OTA are up but BEFORE hw::init() / create_tasks(). The probe
+// engages safe mode (suspending normal boot) when either of these is true:
+//
+//   1) The previous reset reason looks like a crash (panic, task/int
+//      watchdog, brownout, generic WDT). Reboots from POWERON / EXT pin /
+//      software reset (e.g. a clean OTA finalize) are treated as healthy.
+//
+//   2) A magic UDP packet ("HALT-AIO-AG") arrives on port 7777 within a
+//      ~1.5s window. Lets the user force safe mode at will - useful when
+//      the firmware wedges without producing a recognized reset reason
+//      (e.g. an I2C mutex starve that times out a task watchdog the
+//      firmware can't print before the reset).
+//
+// In safe mode the device stays in the OTA-only handler loop forever; no
+// hardware init, no tasks, no AOG UDP listeners. Recovery is: flash a fix
+// via OTA, reboot. The next reset reason will be ESP_RST_SW (clean) and
+// the firmware will resume normal boot.
+void checkAtBoot();
+
+// True if checkAtBoot() decided to engage safe mode.
+bool active();
+
+// Periodic "still alive" log emitted from the safe-mode loop. Self
+// rate-limits so it can be called every loop iteration.
+void tickHeartbeat();
+
+} // namespace safe_mode
+
+#endif // SAFE_MODE_H

--- a/src/network/safe_mode.h
+++ b/src/network/safe_mode.h
@@ -4,23 +4,20 @@
 namespace safe_mode {
 
 // Run the safe-mode probe. Call once during setup(), after Ethernet + UDP
-// logging + OTA are up but BEFORE hw::init() / create_tasks(). The probe
-// engages safe mode (suspending normal boot) when either of these is true:
+// logging + OTA are up but BEFORE hw::init() / create_tasks(). Listens
+// for a magic UDP packet ("HALT-AIO-AG") on port 7779 for a short window
+// (~1.5s); if seen, engages safe mode for the rest of this boot.
 //
-//   1) The previous reset reason looks like a crash (panic, task/int
-//      watchdog, brownout, generic WDT). Reboots from POWERON / EXT pin /
-//      software reset (e.g. a clean OTA finalize) are treated as healthy.
+// Safe mode skips hardware init, task creation, and AOG UDP listeners -
+// the device sits in the OTA-only handler loop forever. Recovery from a
+// boot loop is: watch the UDP log to confirm the device is in fact
+// rebooting, blast HALT-AIO-AG during the next boot's 1.5s window, then
+// OTA-flash a fix. Next reboot proceeds normally (no HALT seen).
 //
-//   2) A magic UDP packet ("HALT-AIO-AG") arrives on port 7777 within a
-//      ~1.5s window. Lets the user force safe mode at will - useful when
-//      the firmware wedges without producing a recognized reset reason
-//      (e.g. an I2C mutex starve that times out a task watchdog the
-//      firmware can't print before the reset).
-//
-// In safe mode the device stays in the OTA-only handler loop forever; no
-// hardware init, no tasks, no AOG UDP listeners. Recovery is: flash a fix
-// via OTA, reboot. The next reset reason will be ESP_RST_SW (clean) and
-// the firmware will resume normal boot.
+// We deliberately do NOT auto-engage on crash-flavored reset reasons -
+// a transient field event (brownout, cosmic-ray panic) shouldn't take
+// the device out of service. The 1.5s window is short enough to feel
+// like normal boot but long enough for a user-driven escape hatch.
 void checkAtBoot();
 
 // True if checkAtBoot() decided to engage safe mode.

--- a/src/network/udp.cpp
+++ b/src/network/udp.cpp
@@ -9,6 +9,9 @@
 #include "gps/gps_heading.h"
 #include "utils/log.h"
 #include "w6100/esp32_sc_w6100.h"
+#if SIMULATOR
+#include "sim/bicycle_sim.h"
+#endif
 
 AsyncUDP autosteer_udp;
 AsyncUDP gps_udp;
@@ -71,15 +74,20 @@ bool init_autosteer_udp() {
 bool init_gps_udp() {
     gps_udp.listen(GPS_UDP_PORT);
     debugf("Listening for GPS UDP on port %d", GPS_UDP_PORT);
+#if SIMULATOR
+    sim::setUdpSender(sendUDPPacketFromGPS);
+    info("GPS UDP wired to bicycle simulator (real GPS UART not used)");
+#else
     gps_main::initGpsCommunication(sendUDPPacketFromGPS, getIP());
-#if GPS_HEADING
+  #if GPS_HEADING
     gps_heading::initGpsCommunication(sendUDPPacketFromGPS, getIP());
-#endif
+  #endif
     gps_udp.onPacket([](AsyncUDPPacket packet) {
             // Convert IPAddress to ip_address for GPS
             ip_address sourceIP = ipAddressToIpAddress(packet.remoteIP());
             gps_main::process_udp_message(packet.data(), packet.length(), sourceIP);
         });
+#endif
     return true;
 }
 

--- a/src/sim/bicycle_sim.cpp
+++ b/src/sim/bicycle_sim.cpp
@@ -1,0 +1,192 @@
+#include "bicycle_sim.h"
+
+#if SIMULATOR
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "autosteer/imu.h"
+#include "autosteer/was.h"
+#include "utils/log.h"
+
+namespace sim {
+
+// World-frame state. heading uses compass convention: 0 = north, +90 = east,
+// increasing clockwise. lat/lon in decimal degrees. Speed in m/s.
+static double  s_lat        = SIM_INIT_LAT;
+static double  s_lon        = SIM_INIT_LON;
+static float   s_headingRad = 0.0f;
+static float   s_speedMps   = SIM_SPEED_MPS;
+static const float s_wheelbase = SIM_WHEELBASE_M;
+
+static bool (*s_udpSend)(const uint8_t*, size_t) = nullptr;
+
+static constexpr float DEG2RAD = 0.0174532925f;
+static constexpr float RAD2DEG = 57.2957795f;
+static constexpr double METERS_PER_DEG_LAT = 111320.0;
+
+static float headingFn() {
+    float deg = s_headingRad * RAD2DEG;
+    while (deg < 0.0f)   deg += 360.0f;
+    while (deg >= 360.0f) deg -= 360.0f;
+    return deg;
+}
+
+static float rollFn() { return 0.0f; }
+
+bool init() {
+    s_lat        = SIM_INIT_LAT;
+    s_lon        = SIM_INIT_LON;
+    s_headingRad = 0.0f;
+    s_speedMps   = SIM_SPEED_MPS;
+
+    imu::IMUInterface ifc;
+    ifc.heading = headingFn;
+    ifc.roll    = rollFn;
+    imu::init(ifc);
+
+    infof("SIM: bicycle model active (L=%.2fm, v=%.2fm/s, lat0=%.5f lon0=%.5f)",
+          s_wheelbase, s_speedMps, s_lat, s_lon);
+    return true;
+}
+
+void tick() {
+    const float dt = SIM_TICK_MS / 1000.0f;
+
+    // WAS gives the (calibrated) steering wheel angle in degrees. Convert to
+    // radians for the bicycle model. Clamp so a runaway WAS reading can't
+    // blow up tan(delta).
+    float deltaDeg = was::get_steering_angle();
+    if (deltaDeg >  60.0f) deltaDeg =  60.0f;
+    if (deltaDeg < -60.0f) deltaDeg = -60.0f;
+    const float deltaRad = deltaDeg * DEG2RAD;
+
+    const float v = s_speedMps;
+    const float L = s_wheelbase;
+
+    // Bicycle model with compass-convention heading:
+    //   north component  -> dx = v cos(psi)
+    //   east  component  -> dy = v sin(psi)
+    //   d psi/dt = (v / L) * tan(delta)
+    const float dHeading = (v / L) * tanf(deltaRad) * dt;
+    s_headingRad += dHeading;
+
+    const float dxNorth = v * cosf(s_headingRad) * dt;
+    const float dyEast  = v * sinf(s_headingRad) * dt;
+
+    s_lat += dxNorth / METERS_PER_DEG_LAT;
+    const double cosLat = cos(s_lat * DEG2RAD);
+    const double mPerDegLon = METERS_PER_DEG_LAT * (cosLat > 1e-6 ? cosLat : 1e-6);
+    s_lon += dyEast / mPerDegLon;
+}
+
+void setUdpSender(bool (*send)(const uint8_t*, size_t)) {
+    s_udpSend = send;
+}
+
+float getHeadingDeg() { return headingFn(); }
+float getRollDeg()    { return 0.0f; }
+double getLat()       { return s_lat; }
+double getLon()       { return s_lon; }
+float getSpeedMps()   { return s_speedMps; }
+
+// NMEA helpers --------------------------------------------------------------
+
+static uint8_t nmeaChecksum(const char* s, size_t len) {
+    uint8_t cs = 0;
+    for (size_t i = 0; i < len; i++) cs ^= (uint8_t)s[i];
+    return cs;
+}
+
+// Format degrees as DDMM.MMMMM (latitude) or DDDMM.MMMMM (longitude). Sign is
+// returned through hemiOut so the caller can append N/S or E/W.
+static void formatLatLon(double deg, bool isLon, char* buf, size_t bufLen, char* hemiOut) {
+    char hemi;
+    if (isLon) {
+        hemi = (deg >= 0) ? 'E' : 'W';
+    } else {
+        hemi = (deg >= 0) ? 'N' : 'S';
+    }
+    *hemiOut = hemi;
+    double abs_deg = (deg >= 0) ? deg : -deg;
+    int    whole_deg = (int)abs_deg;
+    double minutes = (abs_deg - whole_deg) * 60.0;
+    if (isLon) {
+        snprintf(buf, bufLen, "%03d%08.5f", whole_deg, minutes);
+    } else {
+        snprintf(buf, bufLen, "%02d%08.5f", whole_deg, minutes);
+    }
+}
+
+// Synthesize a UTC time string from millis() since boot. AOG mainly cares
+// that the time is monotonically increasing and parses, not that it's right.
+static void formatUtcTime(char* buf, size_t bufLen) {
+    uint32_t total_ms = millis();
+    uint32_t total_s  = total_ms / 1000;
+    uint32_t hh = (total_s / 3600) % 24;
+    uint32_t mm = (total_s / 60) % 60;
+    uint32_t ss = total_s % 60;
+    uint32_t cs = (total_ms % 1000) / 10; // hundredths
+    snprintf(buf, bufLen, "%02u%02u%02u.%02u", hh, mm, ss, cs);
+}
+
+static void formatUtcDate(char* buf, size_t bufLen) {
+    // Fixed valid-looking date - day/month/year mod 100. AOG just needs a
+    // parseable RMC.
+    snprintf(buf, bufLen, "010125");
+}
+
+static bool sendSentence(char* body, size_t bodyLen) {
+    if (!s_udpSend) return false;
+    uint8_t cs = nmeaChecksum(body, bodyLen);
+    char full[160];
+    int n = snprintf(full, sizeof(full), "$%.*s*%02X\r\n", (int)bodyLen, body, cs);
+    if (n <= 0 || n >= (int)sizeof(full)) return false;
+    return s_udpSend((const uint8_t*)full, (size_t)n);
+}
+
+void emitNMEA() {
+    if (!s_udpSend) return;
+
+    char timeBuf[16];
+    formatUtcTime(timeBuf, sizeof(timeBuf));
+    char dateBuf[8];
+    formatUtcDate(dateBuf, sizeof(dateBuf));
+
+    char latBuf[16], lonBuf[20];
+    char nsHemi, ewHemi;
+    formatLatLon(s_lat, false, latBuf, sizeof(latBuf), &nsHemi);
+    formatLatLon(s_lon, true,  lonBuf, sizeof(lonBuf), &ewHemi);
+
+    float headingDeg = getHeadingDeg();
+    float speedKnots = s_speedMps * 1.94384f;
+    float speedKmh   = s_speedMps * 3.6f;
+
+    char body[160];
+    int n;
+
+    // GGA: time, lat, lon, fix=1 (GPS), sats=12, hdop=0.9, alt, geoid sep
+    n = snprintf(body, sizeof(body),
+                 "GNGGA,%s,%s,%c,%s,%c,1,12,0.9,100.0,M,46.9,M,,",
+                 timeBuf, latBuf, nsHemi, lonBuf, ewHemi);
+    if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);
+
+    // RMC: time, status=A (valid), lat, lon, speed (knots), course, date
+    n = snprintf(body, sizeof(body),
+                 "GNRMC,%s,A,%s,%c,%s,%c,%.2f,%.2f,%s,,,A",
+                 timeBuf, latBuf, nsHemi, lonBuf, ewHemi,
+                 (double)speedKnots, (double)headingDeg, dateBuf);
+    if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);
+
+    // VTG: course true, course magnetic, speed knots, speed km/h, mode A
+    n = snprintf(body, sizeof(body),
+                 "GNVTG,%.2f,T,%.2f,M,%.2f,N,%.2f,K,A",
+                 (double)headingDeg, (double)headingDeg,
+                 (double)speedKnots, (double)speedKmh);
+    if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);
+}
+
+} // namespace sim
+
+#endif // SIMULATOR

--- a/src/sim/bicycle_sim.cpp
+++ b/src/sim/bicycle_sim.cpp
@@ -166,22 +166,28 @@ void emitNMEA() {
     char body[160];
     int n;
 
-    // GGA: time, lat, lon, fix=1 (GPS), sats=12, hdop=0.9, alt, geoid sep
+    // GGA: time, lat, lon, fix quality=4 (RTK fixed), sats=14, hdop=0.6,
+    // alt, geoid separation. AgOpenGPS gates engagement on a "good" fix and
+    // typically requires quality >= 4 (RTK fixed) or 5 (RTK float).
     n = snprintf(body, sizeof(body),
-                 "GNGGA,%s,%s,%c,%s,%c,1,12,0.9,100.0,M,46.9,M,,",
+                 "GNGGA,%s,%s,%c,%s,%c,4,14,0.6,100.0,M,46.9,M,1.0,0000",
                  timeBuf, latBuf, nsHemi, lonBuf, ewHemi);
     if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);
 
-    // RMC: time, status=A (valid), lat, lon, speed (knots), course, date
+    // RMC: time, status=A (valid), lat, lon, speed (knots), course, date,
+    // mag var (empty), mode=R (RTK). RMC mode-indicator field is the last
+    // value before the checksum and corresponds to the GGA fix quality:
+    //   A=autonomous, D=DGPS, F=RTK float, R=RTK fixed, E=estimated, N=invalid.
     n = snprintf(body, sizeof(body),
-                 "GNRMC,%s,A,%s,%c,%s,%c,%.2f,%.2f,%s,,,A",
+                 "GNRMC,%s,A,%s,%c,%s,%c,%.2f,%.2f,%s,,,R",
                  timeBuf, latBuf, nsHemi, lonBuf, ewHemi,
                  (double)speedKnots, (double)headingDeg, dateBuf);
     if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);
 
-    // VTG: course true, course magnetic, speed knots, speed km/h, mode A
+    // VTG: course true, course magnetic, speed knots, speed km/h, mode=R
+    // (RTK fixed) to match GGA quality=4.
     n = snprintf(body, sizeof(body),
-                 "GNVTG,%.2f,T,%.2f,M,%.2f,N,%.2f,K,A",
+                 "GNVTG,%.2f,T,%.2f,M,%.2f,N,%.2f,K,R",
                  (double)headingDeg, (double)headingDeg,
                  (double)speedKnots, (double)speedKmh);
     if (n > 0 && n < (int)sizeof(body)) sendSentence(body, n);

--- a/src/sim/bicycle_sim.h
+++ b/src/sim/bicycle_sim.h
@@ -1,0 +1,40 @@
+#ifndef BICYCLE_SIM_H
+#define BICYCLE_SIM_H
+
+#include "config/defines.h"
+
+#if SIMULATOR
+
+#include <Arduino.h>
+#include <stddef.h>
+#include <stdint.h>
+
+namespace sim {
+
+// Initialize the bicycle-model simulator. Registers itself as the IMU heading
+// provider (overriding BNO08X if it was registered earlier). Returns true.
+bool init();
+
+// Advance the model by SIM_TICK_MS. Reads the live WAS angle as the steering
+// input and integrates a kinematic bicycle model.
+void tick();
+
+// Format and emit one round of NMEA sentences (GGA + RMC + VTG) via the
+// previously-registered UDP sender. Call at ~10 Hz to mimic a u-blox at 10 Hz.
+void emitNMEA();
+
+// Register the UDP sender that NMEA sentences should be pushed to. Call this
+// once during udp init so emitNMEA() has somewhere to send.
+void setUdpSender(bool (*send)(const uint8_t*, size_t));
+
+float getHeadingDeg();
+float getRollDeg();
+double getLat();
+double getLon();
+float getSpeedMps();
+
+} // namespace sim
+
+#endif // SIMULATOR
+
+#endif // BICYCLE_SIM_H

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -12,6 +12,9 @@
 #if SIMULATOR
 #include "sim/bicycle_sim.h"
 #endif
+#if TEST_MODE
+#include "test/hw_test.h"
+#endif
 #include "utils/log.h"
 
 [[noreturn]] void was_task(void *pv_parameters) {
@@ -217,6 +220,24 @@ bool create_tasks() {
     );
     if (taskCreated != pdPASS || keyaTaskHandle == nullptr) {
         error("Failed to create Keya task");
+        return false;
+    }
+#endif
+
+#if TEST_MODE
+    delay(100);
+    debug("Creating HW test task...");
+    TaskHandle_t testTaskHandle = nullptr;
+    taskCreated = xTaskCreate(
+        hw::test::task,
+        "hw_test",
+        4096,
+        nullptr,
+        2,                  // low priority - it's just a logger
+        &testTaskHandle
+    );
+    if (taskCreated != pdPASS || testTaskHandle == nullptr) {
+        error("Failed to create HW test task");
         return false;
     }
 #endif

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -6,6 +6,9 @@
 #include "gps/gps_heading.h"
 #include "hardware/was/ads1115_was.h"
 #include "hardware/imu/bno08x_imu.h"
+#if KEYA_MOTOR
+#include "hardware/motor/keya_motor.h"
+#endif
 #include "utils/log.h"
 
 [[noreturn]] void was_task(void *pv_parameters) {
@@ -49,6 +52,17 @@
         vTaskDelay(pdMS_TO_TICKS(1)); // 1kHz update rate
     }
 }
+
+#if KEYA_MOTOR
+[[noreturn]] void keya_task(void *pv_parameters) {
+    for (;;) {
+        hw::KeyaMotor::handler();
+        // handler() blocks up to ~50ms inside twai_receive when idle, so a
+        // short delay here is enough to yield without losing heartbeats.
+        vTaskDelay(pdMS_TO_TICKS(5));
+    }
+}
+#endif
 
 
 bool create_tasks() {
@@ -149,6 +163,24 @@ bool create_tasks() {
 
     if (!taskCreated) {
         error("Failed to create HEADING_GPS task");
+        return false;
+    }
+#endif
+
+#if KEYA_MOTOR
+    delay(100);
+    debug("Creating Keya CAN task...");
+    TaskHandle_t keyaTaskHandle = nullptr;
+    taskCreated = xTaskCreate(
+        keya_task,
+        "keya_task",
+        4096,
+        nullptr,
+        KEYA_TASK_PRIORITY,
+        &keyaTaskHandle
+    );
+    if (taskCreated != pdPASS || keyaTaskHandle == nullptr) {
+        error("Failed to create Keya task");
         return false;
     }
 #endif

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -9,6 +9,9 @@
 #if KEYA_MOTOR
 #include "hardware/motor/keya_motor.h"
 #endif
+#if SIMULATOR
+#include "sim/bicycle_sim.h"
+#endif
 #include "utils/log.h"
 
 [[noreturn]] void was_task(void *pv_parameters) {
@@ -60,6 +63,21 @@
         // handler() blocks up to ~50ms inside twai_receive when idle, so a
         // short delay here is enough to yield without losing heartbeats.
         vTaskDelay(pdMS_TO_TICKS(5));
+    }
+}
+#endif
+
+#if SIMULATOR
+[[noreturn]] void sim_task(void *pv_parameters) {
+    TickType_t lastWake = xTaskGetTickCount();
+    int nmeaCounter = 0;
+    for (;;) {
+        sim::tick();
+        if (++nmeaCounter >= SIM_NMEA_DIVIDER) {
+            nmeaCounter = 0;
+            sim::emitNMEA();
+        }
+        vTaskDelayUntil(&lastWake, pdMS_TO_TICKS(SIM_TICK_MS));
     }
 }
 #endif
@@ -133,6 +151,23 @@ bool create_tasks() {
         return false;
     }
 
+#if SIMULATOR
+    delay(100);
+    debug("Creating SIM task...");
+    TaskHandle_t simTaskHandle = nullptr;
+    taskCreated = xTaskCreate(
+        sim_task,
+        "sim_task",
+        4096,
+        nullptr,
+        SIM_TASK_PRIORITY,
+        &simTaskHandle
+    );
+    if (taskCreated != pdPASS || simTaskHandle == nullptr) {
+        error("Failed to create SIM task");
+        return false;
+    }
+#else
     delay(100);
     debug("Creating MAIN_GPS task...");
     TaskHandle_t gpsTaskHandle = nullptr;
@@ -148,6 +183,7 @@ bool create_tasks() {
         error("Failed to create GPS task");
         return false;
     }
+#endif
 #if GPS_HEADING
     delay(100);
     debug("Creating HEADING_GPS task...");

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -4,7 +4,11 @@
 #include "autosteer/buttons.h"
 #include "gps/gps_module.h"
 #include "gps/gps_heading.h"
+#if KEYA_WAS
+#include "hardware/was/keya_was.h"
+#else
 #include "hardware/was/ads1115_was.h"
+#endif
 #include "hardware/imu/bno08x_imu.h"
 #if KEYA_MOTOR
 #include "hardware/motor/keya_motor.h"
@@ -17,12 +21,16 @@
 #endif
 #include "utils/log.h"
 
+#if !KEYA_WAS
 [[noreturn]] void was_task(void *pv_parameters) {
     for (;;) {
         hw::ADS1115WAS::handler();
         vTaskDelay(pdMS_TO_TICKS(20)); // 50Hz update rate
     }
 }
+#endif
+// Under KEYA_WAS the WAS reading is pulled on demand from the Keya
+// heartbeat (updated by keya_task), so no dedicated WAS task is needed.
 
 [[noreturn]] void imu_task(void *pv_parameters) {
     for (;;) {
@@ -88,21 +96,26 @@
 
 bool create_tasks() {
     debug("Creating tasks...");
+    BaseType_t taskCreated;
+#if !KEYA_WAS
     debug("Creating WAS task...");
     TaskHandle_t wasTaskHandle = nullptr;
-    BaseType_t taskCreated = xTaskCreate(
+    taskCreated = xTaskCreate(
         was_task,
-        "was_task", 
+        "was_task",
         4096,
-        nullptr, 
-        WAS_TASK_PRIORITY, 
+        nullptr,
+        WAS_TASK_PRIORITY,
         &wasTaskHandle
     );
-    
+
     if (taskCreated != pdPASS || wasTaskHandle == nullptr) {
         error("Failed to create WAS task");
         return false;
     }
+#else
+    debug("WAS task skipped (KEYA_WAS=1, encoder is pulled from heartbeat)");
+#endif
 
     delay(100);
     debug("Creating IMU task...");

--- a/src/test/hw_test.cpp
+++ b/src/test/hw_test.cpp
@@ -1,0 +1,95 @@
+#include "hw_test.h"
+
+#if TEST_MODE
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "hardware/hardware.h"
+#include "autosteer/imu.h"
+#include "autosteer/was.h"
+#include "autosteer/buttons.h"
+#include "utils/log.h"
+#if KEYA_MOTOR
+#include "hardware/motor/keya_motor.h"
+#endif
+
+namespace hw {
+namespace test {
+
+[[noreturn]] void task(void *pv) {
+    (void)pv;
+
+    // One-shot summary line at boot so the user can see at a glance what
+    // came up vs what's missing.
+    info("---- TEST MODE: subsystem presence ----");
+    infof("  I2C        : %s", testStatus.i2c_ok        ? "OK" : "MISSING");
+    infof("  Settings   : %s", testStatus.settings_ok   ? "OK" : "MISSING");
+    infof("  Buttons    : %s", testStatus.buttons_ok    ? "OK" : "MISSING");
+    infof("  IMU        : %s", testStatus.imu_ok        ? "OK" : "MISSING");
+    infof("  WAS        : %s", testStatus.was_ok        ? "OK" : "MISSING");
+    infof("  Motor      : %s", testStatus.motor_ok      ? "OK" : "MISSING");
+    infof("  GPS        : %s", testStatus.gps_ok        ? "OK" : "MISSING");
+#if GPS_HEADING
+    infof("  GPSHeading : %s", testStatus.gpsHeading_ok ? "OK" : "MISSING");
+#endif
+    info("---------------------------------------");
+
+    for (;;) {
+        // Heading + roll come from the registered IMU interface (live values).
+        // If IMU init failed they'll just read 0.
+        float heading = imu::get_heading();
+        float roll    = imu::get_roll();
+        int16_t was_raw = was::get_raw_steering_position();
+        float   was_deg = was::get_steering_angle();
+        bool    steerBtn = buttons::steerBntEnabled();
+        bool    workBtn  = buttons::workBntEnabled();
+
+        if (testStatus.imu_ok) {
+            infof("TEST IMU: heading=%6.1f deg, roll=%5.1f deg",
+                  heading, roll);
+        } else {
+            info("TEST IMU: not initialized");
+        }
+
+        if (testStatus.was_ok) {
+            infof("TEST WAS: raw=%5d, angle=%6.2f deg",
+                  (int)was_raw, was_deg);
+        } else {
+            info("TEST WAS: not initialized");
+        }
+
+        if (testStatus.gps_ok) {
+            // gps_main does not currently expose a packet count, so just
+            // confirm init succeeded - the user can also look at the GPS
+            // UDP forwarding (broadcast on AgOpenGPS_UDP_PORT) to see live
+            // NMEA sentences. Nothing emitted here when no fix.
+            info("TEST GPS: init OK (live NMEA broadcast on UDP 9999 if module is talking)");
+        } else {
+            info("TEST GPS: not initialized");
+        }
+
+#if KEYA_MOTOR
+        if (testStatus.motor_ok) {
+            infof("TEST Keya: healthy=%d, current=%u mA, peak=%u mA, pos=%ld deg",
+                  hw::KeyaMotor::isHealthy() ? 1 : 0,
+                  (unsigned)hw::KeyaMotor::getCurrentMA(),
+                  (unsigned)hw::KeyaMotor::getPeakCurrentMA(),
+                  (long)hw::KeyaMotor::getCumulativeDegrees());
+        } else {
+            info("TEST Keya: not initialized");
+        }
+#else
+        infof("TEST PWM motor: enable=%s, work=%s",
+              steerBtn ? "1" : "0", workBtn ? "1" : "0");
+#endif
+
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+} // namespace test
+} // namespace hw
+
+#endif // TEST_MODE

--- a/src/test/hw_test.h
+++ b/src/test/hw_test.h
@@ -1,0 +1,20 @@
+#ifndef HW_TEST_H
+#define HW_TEST_H
+
+#include "config/defines.h"
+
+#if TEST_MODE
+
+namespace hw {
+namespace test {
+
+// FreeRTOS task that periodically logs the live state of every subsystem
+// over the UDP debug stream. Created from create_tasks() when TEST_MODE=1.
+[[noreturn]] void task(void *pv);
+
+} // namespace test
+} // namespace hw
+
+#endif // TEST_MODE
+
+#endif // HW_TEST_H


### PR DESCRIPTION
## Summary

Adds Keya brushless steering motor support over CAN bus as a second motor backend, selectable at build time via `KEYA_MOTOR=1`. The default PWM (Cytron/Danfoss) backend is unchanged on the default `esp32-s3` env.

The work is structured as 6 atomic commits, each independently buildable:

1. **`07623f0`** - Build flag scaffolding. `KEYA_MOTOR`, `KEYA_NO_ACK`, `KEYA_TASK_PRIORITY` defines; `CAN_TX_PIN=21`/`CAN_RX_PIN=47` (transceiver D/R); new `[env:esp32-s3_keya]`. Default build untouched.
2. **`785ef9f`** - CAN/TWAI driver wrapper (`hw::can` namespace). Lifted from the user's ESP Can Tests reference, adapted to AIO-AG conventions (logger calls via `utils/log.h`, no `USBSerial.println`). 250 kbps, accept-all filter, alerts narrowed to actionable conditions. `KEYA_NO_ACK=1` toggles `TWAI_MODE_NO_ACK` for solo bench testing.
3. **`f1a8cc8`** - `KeyaMotor` backend. 29-bit IDs `0x06000001` (TX) / `0x07000001` (RX heartbeat). Frame builders for enable/disable/signed-speed (with the 0xFFFF/0x0000 sign-extension bytes). PWM[0..255]+reversed → signed[-255..255] → Keya signed[-995..998] via `map()`. `isHealthy()` watchdog: 200ms staleness + heartbeat error code check. Implements `motor::MotorInterface` so autosteer is untouched.
4. **`0720bea`** - Wires `KeyaMotor::init()` into `hw::init()` and adds `keya_task` (priority 3, 4096 stack) draining incoming heartbeats. PWM build path unchanged.
5. **`0dd8f4d`** - Engage refusal gate in `autosteer::handler()`. When the heartbeat is stale or error code non-zero, calls `motor::stopMotor()` instead of `driveMotor()` and emits a throttled `error()` log.
6. **`8ac27b3`** - Docs + `[env:esp32-s3_keya_noack]` for sniffer/scope verification. README gains a build-matrix table covering all 7 envs and a bench-test recipe.

## Hardware

- CAN transceiver populated on the AIO-AG PCB
- D pin → GPIO 21 (`CAN_TX_PIN`)
- R pin → GPIO 47 (`CAN_RX_PIN`)
- 250 kbps, 29-bit extended frames

## Test plan
- [x] All build envs build clean: `esp32-s3`, `esp32-s3_dual_gps`, `esp32-s3_keya`, `esp32-s3_keya_noack`
- [x] JTAG-flashed `esp32-s3_keya_noack` to bench device. USB serial boot log confirms:
  - `CAN: NO_ACK mode (bench/sniffer build)`
  - `CAN: started at 250kbps (TX=21 RX=47)`
  - `KeyaMotor initialized`
  - `Creating Keya CAN task...`
  - `System ready` (full hw::init succeeded with Keya in the chain)
- [ ] **Deferred (no Keya motor on bench):** verify a real Keya motor produces heartbeats at ~50 Hz, `isHealthy()` flips true, engage drives the motor, the engagement gate refuses cleanly when the bus goes silent.