### PR TITLE
Inject git short SHA into boot banner

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,7 @@ lib_deps =
 	adafruit/Adafruit BNO08x@^1.2.3
 	sparkfun/SparkFun u-blox GNSS Arduino Library @ ^2.2.20
 	https://github.com/Xyntexx/WebServer_ESP32_SC_W6100
+extra_scripts = pre:scripts/inject_git_rev.py
 build_flags =
 	-DARDUINO_USB_MODE=1
 	-DGPS_HEADING=0

--- a/scripts/inject_git_rev.py
+++ b/scripts/inject_git_rev.py
@@ -1,0 +1,32 @@
+"""PlatformIO pre-build hook: inject the current git short SHA (with a
+``-dirty`` suffix when the working tree has uncommitted changes) as the
+``GIT_REV`` build define. Falls back to ``unknown`` outside a git work
+tree (e.g. CI building a tarball)."""
+
+import subprocess
+
+Import("env")  # noqa: F821 - provided by PlatformIO
+
+
+def _git(args):
+    try:
+        out = subprocess.check_output(
+            ["git"] + args,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8").strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def _git_rev():
+    sha = _git(["rev-parse", "--short", "HEAD"])
+    if not sha:
+        return "unknown"
+    dirty = _git(["status", "--porcelain"])
+    return sha + ("-dirty" if dirty else "")
+
+
+rev = _git_rev()
+env.Append(CPPDEFINES=[("GIT_REV", env.StringifyMacro(rev))])  # noqa: F821
+print("inject_git_rev: GIT_REV=" + rev)

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -18,6 +18,13 @@
 #define FIRMWARE_VERSION "0.0.1"
 #define BUILD_DATE __DATE__ " " __TIME__
 
+// GIT_REV is injected as a quoted string by scripts/inject_git_rev.py at
+// build time (the short SHA, with a "-dirty" suffix when the working tree
+// has uncommitted changes). Fall back when building outside a git tree.
+#ifndef GIT_REV
+#define GIT_REV "unknown"
+#endif
+
 #define LOGSerial USBSerial
 
 #define GPSSerial Serial2

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -15,7 +15,9 @@ void setup() {
   initLogging();
 
   // Log system startup
-  info("System Startup - Version " + String(FIRMWARE_VERSION) + " (" + String(BUILD_DATE) + ")");
+  info("System Startup - Version " + String(FIRMWARE_VERSION)
+       + " rev " + String(GIT_REV)
+       + " (" + String(BUILD_DATE) + ")");
   LOGSerial.println("//////////////////////////");
   LOGSerial.println("/////  ESP32-AIO-AG  /////");
   LOGSerial.println("//////////////////////////");


### PR DESCRIPTION
## Summary
- Pre-build script writes current commit's short SHA into \`GIT_REV\`
- Boot banner now logs \`Version 0.0.1 rev aadc25d-dirty (May 2 2026 ...)\`
- \`-dirty\` suffix appears whenever the working tree has uncommitted changes

## Test plan
- [x] Build prints \`inject_git_rev: GIT_REV=...\` during compile
- [ ] Device boot log shows the rev (verify on next live boot)