### PR TITLE
Async UDP TX queue: decouple sends from realtime path

### DIFF
--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -185,6 +185,18 @@
 #define HEADING_TASK_PRIORITY (10)
 #define KEYA_TASK_PRIORITY 3
 #define SIM_TASK_PRIORITY  4
+#define UDP_TX_TASK_PRIORITY 1
+
+// Outbound-UDP queue. Producers (autosteer / GPS / heading / sim) enqueue
+// here instead of calling AsyncUDP::writeTo() directly so a stalled W6100
+// or wedged lwIP path can never block the 1 kHz autosteer/motor loop or
+// the lwIP RX callback. The drainer task owns all real sends.
+//
+// MAX_PAYLOAD covers the largest current packet (NMEA buffer is 256;
+// AOG packets are < 32). DEPTH=32 holds ~1 s of autosteer chatter plus
+// a typical NMEA burst, with a single 8 KB static allocation.
+#define UDP_TX_QUEUE_DEPTH   32
+#define UDP_TX_MAX_PAYLOAD   256
 
 
 #define AgOpenGPS_UDP_PORT 9999

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -4,6 +4,7 @@
 #include "autosteer/autosteer.h"
 #include "WebServer_ESP32_SC_W6100.h"
 #include "network/udp.h"
+#include "network/udp_tx.h"
 #include "network/ota.h"
 #include "network/safe_mode.h"
 #include "../hardware/i2c_manager.h"
@@ -27,6 +28,11 @@ void setup() {
   initializeEthernet();
   debug("Ethernet initialized");
   initUDPLogging();
+
+  // Drainer for outbound UDP. Spawned before OTA / hw / tasks so the
+  // queue exists before anything tries to enqueue. Producers never
+  // touch AsyncUDP directly anymore - they push descriptors here.
+  udp_tx::init();
 
   // Bring OTA up before hardware init so a bad flash that hangs in
   // hw::init() can still be recovered remotely.

--- a/src/network/udp.cpp
+++ b/src/network/udp.cpp
@@ -1,6 +1,7 @@
 #include "udp.h"
 #include "../autosteer/udp_io.h"
 #include "../gps/gps_module.h"
+#include "udp_tx.h"
 
 #include <AsyncUDP.h>
 #include <WiFi.h>
@@ -49,17 +50,28 @@ bool broadcastUDPPacket(AsyncUDP& udp, uint16_t remotePort, const uint8_t* data,
     return udp.writeTo(data, len, ETH.broadcastIP(), remotePort) > 0;
 }
 
-// UDP packet sending function for autosteer
-static bool sendUDPPacketFromAutosteer(const uint8_t* data, size_t len) {
+// Drainer-side senders. The udp_tx task calls these to do the actual
+// AsyncUDP::writeTo() - if the W6100/lwIP path wedges, it's the drainer
+// that blocks here, never the producer.
+static bool drainAutosteerToUdp(const uint8_t* data, size_t len) {
     return broadcastUDPPacket(autosteer_udp, AgOpenGPS_UDP_PORT, data, len);
 }
-
-// UDP packet sending function for GPS
-static bool sendUDPPacketFromGPS(const uint8_t* data, size_t len) {
+static bool drainGpsToUdp(const uint8_t* data, size_t len) {
     return broadcastUDPPacket(gps_udp, AgOpenGPS_UDP_PORT, data, len);
 }
 
+// Producer-facing send functions. These run in the caller's context
+// (1 kHz autosteer, lwIP RX callback, GPS UART loop) and only enqueue;
+// the drainer task does the network I/O.
+static bool sendUDPPacketFromAutosteer(const uint8_t* data, size_t len) {
+    return udp_tx::enqueue(udp_tx::Channel::Autosteer, data, len);
+}
+static bool sendUDPPacketFromGPS(const uint8_t* data, size_t len) {
+    return udp_tx::enqueue(udp_tx::Channel::GPS, data, len);
+}
+
 bool init_autosteer_udp() {
+    udp_tx::registerChannel(udp_tx::Channel::Autosteer, drainAutosteerToUdp);
     autosteer_udp.listen(STEER_UDP_PORT);
     debugf("Listening for autosteer UDP on port %d", STEER_UDP_PORT);
     initAutosteerCommunication(sendUDPPacketFromAutosteer, getIP());
@@ -72,6 +84,7 @@ bool init_autosteer_udp() {
 }
 
 bool init_gps_udp() {
+    udp_tx::registerChannel(udp_tx::Channel::GPS, drainGpsToUdp);
     gps_udp.listen(GPS_UDP_PORT);
     debugf("Listening for GPS UDP on port %d", GPS_UDP_PORT);
 #if SIMULATOR

--- a/src/network/udp_tx.cpp
+++ b/src/network/udp_tx.cpp
@@ -1,0 +1,159 @@
+#include "udp_tx.h"
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+#include <string.h>
+
+#include "config/defines.h"
+#include "utils/log.h"
+
+namespace udp_tx {
+
+namespace {
+
+struct Descriptor {
+    uint8_t  channel;
+    uint16_t len;
+    uint8_t  payload[UDP_TX_MAX_PAYLOAD];
+};
+
+constexpr size_t CHANNEL_COUNT = static_cast<size_t>(Channel::_COUNT);
+
+// Static queue storage: avoids heap allocation for ~8 KB of buffer.
+StaticQueue_t       s_queueCb;
+uint8_t             s_queueStorage[UDP_TX_QUEUE_DEPTH * sizeof(Descriptor)];
+QueueHandle_t       s_queue       = nullptr;
+
+StaticTask_t        s_taskCb;
+StackType_t         s_taskStack[4096];
+TaskHandle_t        s_task        = nullptr;
+
+SendFn              s_senders[CHANNEL_COUNT] = {nullptr};
+volatile Stats      s_stats                  = {};
+
+bool                s_inited = false;
+
+void drainer(void*) {
+    Descriptor d;
+    for (;;) {
+        if (xQueueReceive(s_queue, &d, portMAX_DELAY) != pdTRUE) continue;
+
+        if (d.channel >= CHANNEL_COUNT) {
+            // Defensive - corrupt descriptor; count and skip.
+            s_stats.send_failed++;
+            continue;
+        }
+
+        SendFn fn = s_senders[d.channel];
+        if (!fn) {
+            s_stats.dropped_unreg++;
+            continue;
+        }
+
+        if (fn(d.payload, d.len)) {
+            s_stats.sent_ok++;
+            s_stats.last_drain_ms = millis();
+        } else {
+            s_stats.send_failed++;
+        }
+    }
+}
+
+} // namespace
+
+bool init() {
+    if (s_inited) return true;
+
+    s_queue = xQueueCreateStatic(
+        UDP_TX_QUEUE_DEPTH,
+        sizeof(Descriptor),
+        s_queueStorage,
+        &s_queueCb);
+    if (!s_queue) {
+        error("udp_tx: queue create failed");
+        return false;
+    }
+
+    s_task = xTaskCreateStatic(
+        drainer,
+        "udp_tx",
+        sizeof(s_taskStack) / sizeof(StackType_t),
+        nullptr,
+        UDP_TX_TASK_PRIORITY,
+        s_taskStack,
+        &s_taskCb);
+    if (!s_task) {
+        error("udp_tx: task create failed");
+        return false;
+    }
+
+    s_inited = true;
+    infof("udp_tx: started (depth=%d, payload=%d, prio=%d)",
+          UDP_TX_QUEUE_DEPTH, UDP_TX_MAX_PAYLOAD, UDP_TX_TASK_PRIORITY);
+    return true;
+}
+
+void registerChannel(Channel ch, SendFn fn) {
+    size_t i = static_cast<size_t>(ch);
+    if (i < CHANNEL_COUNT) {
+        s_senders[i] = fn;
+    }
+}
+
+bool enqueue(Channel ch, const uint8_t* data, size_t len) {
+    if (!s_inited || !s_queue) return false;
+    if (len > UDP_TX_MAX_PAYLOAD) {
+        s_stats.dropped_oversize++;
+        return false;
+    }
+
+    Descriptor d;
+    d.channel = static_cast<uint8_t>(ch);
+    d.len     = static_cast<uint16_t>(len);
+    memcpy(d.payload, data, len);
+
+    // Non-blocking. On full, evict oldest and retry once - we'd rather
+    // a stale descriptor go than make a producer wait for the network.
+    if (xQueueSend(s_queue, &d, 0) != pdTRUE) {
+        Descriptor evict;
+        xQueueReceive(s_queue, &evict, 0);
+        s_stats.dropped_full++;
+        if (xQueueSend(s_queue, &d, 0) != pdTRUE) {
+            // Should never happen on a single-producer-per-channel path,
+            // but keep the failure observable rather than silently lost.
+            s_stats.send_failed++;
+            return false;
+        }
+    }
+
+    s_stats.enqueued++;
+    UBaseType_t depth = uxQueueMessagesWaiting(s_queue);
+    if (depth > s_stats.depth_high_water) {
+        s_stats.depth_high_water = (uint16_t)depth;
+    }
+    return true;
+}
+
+Stats stats() {
+    // Volatile -> non-volatile copy. Each uint32 read is atomic on
+    // Xtensa, so the snapshot is consistent per-field even if the
+    // drainer updates concurrently.
+    Stats out;
+    out.enqueued         = s_stats.enqueued;
+    out.dropped_full     = s_stats.dropped_full;
+    out.dropped_oversize = s_stats.dropped_oversize;
+    out.dropped_unreg    = s_stats.dropped_unreg;
+    out.sent_ok          = s_stats.sent_ok;
+    out.send_failed      = s_stats.send_failed;
+    out.last_drain_ms    = s_stats.last_drain_ms;
+    out.depth_high_water = s_stats.depth_high_water;
+    return out;
+}
+
+uint32_t lastDrainMillis() {
+    return s_stats.last_drain_ms;
+}
+
+} // namespace udp_tx

--- a/src/network/udp_tx.h
+++ b/src/network/udp_tx.h
@@ -1,0 +1,58 @@
+#ifndef UDP_TX_H
+#define UDP_TX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace udp_tx {
+
+// Logical send channels. Each channel resolves to a registered sender
+// function that the drainer task invokes when it pops a queued payload.
+enum class Channel : uint8_t {
+    Autosteer = 0,
+    GPS       = 1,
+    _COUNT
+};
+
+using SendFn = bool (*)(const uint8_t* data, size_t len);
+
+struct Stats {
+    uint32_t enqueued;
+    uint32_t dropped_full;     // queue was full, oldest descriptor was evicted
+    uint32_t dropped_oversize; // payload exceeded UDP_TX_MAX_PAYLOAD
+    uint32_t dropped_unreg;    // channel had no sender registered
+    uint32_t sent_ok;
+    uint32_t send_failed;      // sender returned false
+    uint32_t last_drain_ms;    // millis() when the drainer last completed a send
+    uint16_t depth_high_water;
+};
+
+// Create the queue + spawn the drainer task. Idempotent. Must be called
+// before any producer enqueues - call as early as possible in setup(),
+// before initUDP() and before tasks that send (gps_task, autoSteerTask).
+bool init();
+
+// Wire the underlying send function for a channel. Channels with no
+// registered sender at drain time get counted as dropped_unreg and
+// silently skipped - the drainer never blocks waiting for one.
+void registerChannel(Channel ch, SendFn fn);
+
+// Non-blocking enqueue. Safe from any context (lwIP RX callback, 1 kHz
+// task, GPS UART loop). Returns true when the descriptor is queued; on
+// a full queue the oldest descriptor is dropped and the new one queued
+// (the bumped dropped_full counter records this). Returns false only
+// when the payload is too large or the module is uninitialized.
+bool enqueue(Channel ch, const uint8_t* data, size_t len);
+
+// Snapshot of telemetry counters. Reads are atomic per-field on Xtensa
+// (32-bit aligned uint32), so a snapshot may straddle a sender update,
+// but each field is internally consistent.
+Stats stats();
+
+// Shorthand for stats().last_drain_ms - cheap polling for the safety
+// task in PR2 to detect a wedged TX path.
+uint32_t lastDrainMillis();
+
+} // namespace udp_tx
+
+#endif // UDP_TX_H


### PR DESCRIPTION
## Summary
- Previously synchronous \`AsyncUDP::writeTo()\` from the 1 kHz autosteer/motor loop, the lwIP RX callback, and GPS forwarding tasks could freeze the control path when the W6100/lwIP path wedges (the v0.0.9 field-failure mode).
- New \`udp_tx\` module owns a single drainer task; producers enqueue and never block. Drop-oldest on full, statically allocated (~8 KB).
- Compile-verified across all 7 envs.

## Bench verification (pending)
- [ ] Boot log shows \`udp_tx: started (depth=32, payload=256, prio=1)\`
- [ ] AOG running: \`stats().enqueued ~= sent_ok\`, no \`dropped_full\` under normal load
- [ ] **Cable-pull test:** unplug Ethernet for 3-4 s, reconnect. \`autoSteerTask\` heartbeat must keep ticking the entire time, then traffic resumes
- [ ] All envs flash and boot

## Followups
- PR2: high-priority safety task that stops the motor on stale guidance / stale autosteer tick (consumes \`udp_tx::lastDrainMillis\`)
- PR3: lower W6100 SPI clock 25 -> 16 MHz
- PR4: 1 Hz ALIVE heartbeat broadcasting queue stats