### PR TITLE
Safety task: stop motor on stale guidance / wedged control loop

### DIFF
--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -1,6 +1,7 @@
 #include "autosteer.h"
 #include "pid_controller.h"
 #include "buttons.h"
+#include "safety.h"
 #include "udp_io.h"
 #include "utils/log.h"
 #include "was.h"
@@ -26,6 +27,8 @@ static bool overcurrentLatched = false;
 #endif
 
 void handler() {
+    safety::noteAutosteerTick();
+
     bool hwEnable = buttons::steerBntEnabled();
     bool swEnable = getSwSwitchStatus();
 

--- a/src/autosteer/safety.cpp
+++ b/src/autosteer/safety.cpp
@@ -1,0 +1,144 @@
+#include "safety.h"
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "config/defines.h"
+#include "autosteer.h"
+#include "buttons.h"
+#include "motor.h"
+#include "udp_io.h"
+#include "utils/log.h"
+
+#if KEYA_MOTOR
+#include "hardware/motor/keya_motor.h"
+#endif
+
+namespace safety {
+
+namespace {
+
+volatile uint32_t s_autosteerTicks  = 0;
+volatile uint32_t s_lastTickMs      = 0;
+volatile uint32_t s_stops           = 0;
+
+StaticTask_t       s_taskCb;
+StackType_t        s_taskStack[2048];
+
+constexpr uint32_t TICK_MS                = SAFETY_TICK_MS;
+constexpr uint32_t AUTOSTEER_STALE_MS     = SAFETY_AUTOSTEER_STALE_MS;
+
+enum class Reason : uint8_t {
+    None = 0,
+    Disengaged,
+    GuidanceStale,
+    AutosteerStale,
+    KeyaUnhealthy,
+};
+
+const char* reasonStr(Reason r) {
+    switch (r) {
+        case Reason::None:           return "none";
+        case Reason::Disengaged:     return "disengaged";
+        case Reason::GuidanceStale:  return "guidance-stale";
+        case Reason::AutosteerStale: return "autosteer-stale";
+        case Reason::KeyaUnhealthy:  return "keya-unhealthy";
+    }
+    return "?";
+}
+
+// Check the safety conditions and return the first one that requires a
+// stop. Order matters only for log clarity. We don't try to enumerate
+// every reason - first match wins.
+Reason checkConditions(uint32_t now) {
+    // 1) Composite engage state - if either physical button or software
+    //    switch is off, autosteer should be stopped. This is what
+    //    autosteer::handler() already enforces; the safety task just
+    //    re-asserts it independent of whether handler() got CPU.
+    if (!autosteer::isEngaged()) {
+        return Reason::Disengaged;
+    }
+
+    // 2) AOG guidance stale - autosteer setpoint is older than
+    //    WATCHDOG_TIMEOUT (currently 500 ms). On the bench with no AOG,
+    //    this is the dominant trigger. In the field this would fire
+    //    if the network drops (the original v0.0.9 failure mode).
+    if (!guidancePacketValid()) {
+        return Reason::GuidanceStale;
+    }
+
+    // 3) Autosteer task heartbeat - if the 1 kHz handler hasn't run
+    //    within AUTOSTEER_STALE_MS, something is starving it (network
+    //    wedge, mutex pile-up). Stop the motor regardless.
+    uint32_t lastTick = s_lastTickMs;
+    if (lastTick != 0 && (now - lastTick) > AUTOSTEER_STALE_MS) {
+        return Reason::AutosteerStale;
+    }
+
+#if KEYA_MOTOR
+    // 4) Keya heartbeat lost - the existing autosteer handler refuses
+    //    to engage if unhealthy, but if it transitions to unhealthy
+    //    mid-engage we want to drop the motor immediately.
+    if (!hw::KeyaMotor::isHealthy()) {
+        return Reason::KeyaUnhealthy;
+    }
+#endif
+
+    return Reason::None;
+}
+
+[[noreturn]] void task(void*) {
+    Reason lastReason = Reason::None;
+    for (;;) {
+        uint32_t now = millis();
+        Reason r = checkConditions(now);
+
+        if (r != Reason::None) {
+            motor::stopMotor();
+            if (r != lastReason) {
+                // Only log on transition - we'd rather flood than miss
+                // it, but actual tractor-field runs don't need a log
+                // line every 20 ms once the tractor is parked.
+                warningf("safety: stop reason=%s", reasonStr(r));
+                s_stops++;
+            }
+        }
+        lastReason = r;
+
+        vTaskDelay(pdMS_TO_TICKS(TICK_MS));
+    }
+}
+
+} // namespace
+
+bool init() {
+    TaskHandle_t h = xTaskCreateStatic(
+        task,
+        "safety",
+        sizeof(s_taskStack) / sizeof(StackType_t),
+        nullptr,
+        SAFETY_TASK_PRIORITY,
+        s_taskStack,
+        &s_taskCb);
+    if (!h) {
+        error("safety: task create failed");
+        return false;
+    }
+    infof("safety: started (tick=%lu ms, prio=%d, autosteer-stale=%lu ms)",
+          (unsigned long)TICK_MS,
+          SAFETY_TASK_PRIORITY,
+          (unsigned long)AUTOSTEER_STALE_MS);
+    return true;
+}
+
+void noteAutosteerTick() {
+    s_autosteerTicks++;
+    s_lastTickMs = millis();
+}
+
+uint32_t stopCount() {
+    return s_stops;
+}
+
+} // namespace safety

--- a/src/autosteer/safety.h
+++ b/src/autosteer/safety.h
@@ -1,0 +1,36 @@
+#ifndef SAFETY_H
+#define SAFETY_H
+
+#include <stdint.h>
+
+namespace safety {
+
+// High-priority motor-safety task. Runs at SAFETY_TASK_PRIORITY (above
+// every task that could legitimately drive the motor) and continuously
+// asserts that if any of the safety conditions are not met, the motor
+// is stopped - independent of whether the autosteer task or the network
+// stack is healthy.
+//
+// What it monitors (read directly from existing module state, no IPC):
+//   1. guidancePacketValid()  - AOG steer-data RX freshness
+//   2. autosteer::isEngaged() - composite hw + sw enable
+//   3. KeyaMotor::isHealthy() (KEYA_MOTOR builds only) - heartbeat alive
+//   4. autosteer-task heartbeat (noteAutosteerTick) - control loop alive
+//
+// What it does: motor::stopMotor() when any of those drops. Never
+// engages the motor. Never sends UDP. Never touches I2C/SPI. Never
+// blocks on a queue.
+bool init();
+
+// Called from autosteer::handler() on every tick. Bumps an atomic
+// counter the safety task watches for staleness; if the counter hasn't
+// moved within SAFETY_AUTOSTEER_STALE_MS the safety task force-stops.
+void noteAutosteerTick();
+
+// Telemetry. Number of safety stops since boot (any reason) - useful
+// for knowing whether the safety task ever fired in a session.
+uint32_t stopCount();
+
+} // namespace safety
+
+#endif // SAFETY_H

--- a/src/config/defines.h
+++ b/src/config/defines.h
@@ -187,6 +187,21 @@
 #define SIM_TASK_PRIORITY  4
 #define UDP_TX_TASK_PRIORITY 1
 
+// Safety task. Higher priority than every task that can drive the
+// motor (buttons=6, autosteer=5) so it can preempt them and force a
+// stop if any safety condition fails. Lower than GPS/heading=10 so
+// GPS forwarding doesn't get starved by the safety check.
+#define SAFETY_TASK_PRIORITY 7
+// How often the safety task wakes up to recheck conditions. 20 ms =
+// 50 Hz, well above the 200 ms / 500 ms staleness thresholds it
+// monitors and cheap on CPU.
+#define SAFETY_TICK_MS 20
+// Stop the motor if the autosteer handler hasn't bumped its tick
+// counter in this many ms. Autosteer runs at 1 kHz so 100 ms is a
+// generous margin against legitimate scheduling jitter while still
+// catching a wedged control path quickly.
+#define SAFETY_AUTOSTEER_STALE_MS 100
+
 // Outbound-UDP queue. Producers (autosteer / GPS / heading / sim) enqueue
 // here instead of calling AsyncUDP::writeTo() directly so a stalled W6100
 // or wedged lwIP path can never block the 1 kHz autosteer/motor loop or

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -2,6 +2,7 @@
 
 #include "autosteer/autosteer.h"
 #include "autosteer/buttons.h"
+#include "autosteer/safety.h"
 #include "gps/gps_module.h"
 #include "gps/gps_heading.h"
 #if KEYA_WAS
@@ -97,6 +98,16 @@
 bool create_tasks() {
     debug("Creating tasks...");
     BaseType_t taskCreated;
+
+    // Safety task first - it monitors autosteer-handler heartbeat and
+    // forces motor stop on stale guidance / wedged control loop. Highest
+    // priority of anything that touches the motor (above buttons=6,
+    // autosteer=5).
+    if (!safety::init()) {
+        error("Failed to create safety task");
+        return false;
+    }
+
 #if !KEYA_WAS
     debug("Creating WAS task...");
     TaskHandle_t wasTaskHandle = nullptr;


### PR DESCRIPTION
## Summary
Adds a high-priority motor-safety task (priority 7, above buttons=6 / autosteer=5) that runs independently of the autosteer task and continuously asserts the motor is stopped when any of these fail:

- \`autosteer::isEngaged()\` - composite hw + sw enable
- \`guidancePacketValid()\` - AOG steer-data RX freshness
- autosteer-handler tick heartbeat (within 100 ms)
- \`KeyaMotor::isHealthy()\` (KEYA_MOTOR builds only)

Backed-up redundancy for the failure mode in PR #6: even if the autosteer task is wedged or the network has stalled, the safety task keeps running and force-stops the motor.

## Stacks on PR #6
Base branch is \`feature/udp-tx-queue\` (PR #6). Will rebase to master after #6 merges.

## Bench verification (done)
- [x] All envs build clean (PWM, Keya, Keya+sim+WAS, TEST_MODE)
- [x] Boot log: \`safety: started (tick=20 ms, prio=7, autosteer-stale=100 ms)\`
- [x] Idle state: \`safety: stop reason=disengaged\` fires once on entry, silent thereafter (correct - logs only on reason change)
- [x] \`udp_tx\` still healthy alongside the new task

## Pending field tests
- [ ] Engage with AOG, pull Ethernet cable -> motor must stop within ~500 ms (\`WATCHDOG_TIMEOUT\`) via \`guidance-stale\` reason
- [ ] Artificially block autosteer handler -> safety task must fire \`autosteer-stale\` and stop motor (debug-only test; remove block before merge)