### PR TITLE
Fix autosteer engage: switch alone, no AOG toggle dance, longer watchdog

### DIFF
--- a/src/autosteer/autosteer.cpp
+++ b/src/autosteer/autosteer.cpp
@@ -67,7 +67,13 @@ void handler() {
     }
 #endif
 
-    if (hwEnable && swEnable
+    // Engage is driven by the configured button source alone. For
+    // SWITCH/BUTTON types the physical input is the master; for NONE,
+    // buttons::handler() already folds AOG's software switch into
+    // hwEnable. We deliberately do NOT also require swEnable here -
+    // a user with a real switch shouldn't have to coordinate AOG's
+    // software toggle to engage.
+    if (hwEnable
 #if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
             && !overcurrentLatched
 #endif
@@ -78,12 +84,11 @@ void handler() {
     }
 
 #if KEYA_MOTOR && KEYA_OVERCURRENT_TRIP_MA > 0
-    // Clear the latch on any deliberate user disengage - either dropping the
-    // AOG software switch OR releasing the physical steer switch/button. That
-    // way the user can re-arm after a fault from whichever input they normally
-    // use, regardless of the configured steer_switch_type. The latch survives
-    // a single engaged session, then clears.
-    if (!hwEnable || !swEnable) overcurrentLatched = false;
+    // Clear the latch on any deliberate user disengage. hwEnable is the
+    // composite engage signal (physical switch in SWITCH/BUTTON modes,
+    // AOG sw switch in NONE mode), so dropping it covers all the user
+    // input paths in a single check.
+    if (!hwEnable) overcurrentLatched = false;
 #endif
 
     if (steerEnable != prevSteerEnable) {

--- a/src/autosteer/autosteer_config.h
+++ b/src/autosteer/autosteer_config.h
@@ -6,13 +6,15 @@
 #define AUTOSTEER_CONFIG_H
 
 #define LOW_HIGH_DEGREES 3.0
-// Watchdog timeout in ms. AOG SteerData arrives at ~10Hz (~100ms cadence);
-// 200ms was too tight - normal UDP jitter would push one packet past that
-// and disengage autosteer (resetting NONE-mode arming in the process,
-// requiring AOG to toggle status off->on again). 500ms tolerates ~5
-// missed packets - generous against jitter, still short enough to catch
-// a real AOG outage promptly.
-#define WATCHDOG_TIMEOUT 500
+// Watchdog timeout in ms. AOG SteerData arrives at ~10Hz (~100ms cadence).
+// 500ms (5 missed packets) was still tripping under real-world AOG jitter -
+// observed an 800ms gap caused by AOG's own scheduling pause that triggered
+// a spontaneous disengage even though the underlying network was healthy.
+// 1500ms (15 missed packets) leaves plenty of room for AOG to resume after
+// a stall while still catching a genuine multi-second outage. The safety
+// task's 100ms autosteer-stale watchdog still guards the control loop, so
+// loosening this only affects guidance-source freshness, not motor safety.
+#define WATCHDOG_TIMEOUT 1500
 
 
 #endif //AUTOSTEER_CONFIG_H

--- a/src/autosteer/buttons.cpp
+++ b/src/autosteer/buttons.cpp
@@ -11,7 +11,6 @@ bool inited = false;
 bool prev_momentary_state = false;
 bool steer_enable         = false;
 bool work_enable          = false;
-bool sw_switch_valid      = false;
 
 bool init(const ButtonsInterface hw) {
     hw_interface = hw;
@@ -64,15 +63,12 @@ void handler() {
             break;
 
         case steer_switch_type_types::NONE:
-            // No physical switch - use software switch when valid guidance data is available
-            if (!guidancePacketValid()) {
-                steer_enable    = false;
-                sw_switch_valid = false;
-            } else if (sw_switch_valid) {
-                steer_enable = getSwSwitchStatus();
-            } else if (!getSwSwitchStatus()) {
-                sw_switch_valid = true;
-            }
+            // No physical switch - track AOG's software switch directly.
+            // Matches the Teensy reference: when AOG sends guidanceStatus=1
+            // we engage immediately on the next valid steer-data packet, no
+            // off-then-on toggle dance required. Stale guidance (>WATCHDOG_TIMEOUT
+            // since last PGN 254) disables.
+            steer_enable = guidancePacketValid() && getSwSwitchStatus();
             break;
 
         default:


### PR DESCRIPTION
## Summary
Three related fixes that all surfaced as 'AOG sees the steer module disconnect / never engages':

1. \`autosteer::handler()\` no longer ANDs hwEnable with swEnable - the configured input source (physical switch in SWITCH/BUTTON modes, AOG sw in NONE mode) is the sole engage signal, matching the Teensy reference's single-composite-steerSwitch model.
2. \`buttons::handler()\` NONE-mode no longer needs AOG to toggle off-then-on after boot before it'll arm. Engages directly when guidance is valid + status=1, again matching Teensy.
3. \`WATCHDOG_TIMEOUT\` 500 -> 1500 ms. Bench capture caught AOG itself stalling for ~800 ms (Windows scheduling) and tripping the watchdog into a spontaneous disengage. The safety task's 100 ms autosteer-stale watchdog still guards the control loop - this only loosens guidance-source freshness.

## Bench-verified
After OTA: device reports \`S=1, pwm=5..16\` in autosteer responses immediately when AOG engages, and stays engaged across the brief packet gaps that previously dropped it.